### PR TITLE
block fallthrough

### DIFF
--- a/gui/TEvdMainFrame.cc
+++ b/gui/TEvdMainFrame.cc
@@ -67,6 +67,7 @@ Bool_t TEvdMainFrame::ProcessMessage(Long_t msg, Long_t parm1, Long_t parm2) {
 	}
 	break;
       }
+      break;
     default:
       if (vm->DebugLevel() > 0) {
 	printf(" *** TStnFrame::ProcessMessage msg: %li parm1: %li parm2: %li\n",

--- a/gui/TStnFrame.cc
+++ b/gui/TStnFrame.cc
@@ -685,6 +685,7 @@ Bool_t TStnFrame::ProcessMessage(Long_t msg, Long_t parm1, Long_t parm2) {
 	}
 	break;
       }
+      break;
     default:
       if (vm->DebugLevel() > 0) {
 	printf(" *** TStnFrame::ProcessMessage msg = %li parm1 = %li parm2 = %li\n", 


### PR DESCRIPTION

This fixes the warnings due to switch implicit fallthrough.  Please check if fallthrough was intended, if so, [here](https://gcc.gnu.org/onlinedocs/gcc-13.1.0/gcc/Warning-Options.html#index-Wimplicit-fallthrough) is how to allow fallthrough