### PR TITLE
Revert "Revert "remove mu2eInterfaces lib""

### DIFF
--- a/gui/SConscript
+++ b/gui/SConscript
@@ -46,7 +46,6 @@ def local_build():
                          'mu2e_ConditionsService',
                          'mu2e_GeomPrimitives',
                          'mu2e_Mu2eUtilities',
-                         'mu2e_Mu2eInterfaces',
                          babarlibs,
                          'art_Framework_Core',
                          'art_Framework_Services_Registry',

--- a/mod/SConscript
+++ b/mod/SConscript
@@ -55,7 +55,6 @@ def local_build():
                  'mu2e_DataProducts',
                  'mu2e_CaloMC',
                  'mu2e_BTrkData',
-                 'mu2e_Mu2eInterfaces',
                  babarlibs,
                  'CLHEP',
                  'art_Framework_Core',

--- a/print/SConscript
+++ b/print/SConscript
@@ -45,7 +45,6 @@ def local_build():
                         'mu2e_DataProducts',
                         'mu2e_CaloMC',
                         'mu2e_BTrkData',
-                        'mu2e_Mu2eInterfaces',
                         
 #                            'HepPDT',
 #                        'HepPID',


### PR DESCRIPTION
Reverts Mu2e/Stntuple#16 which restores #15 that had been merged too soon (It needed to after Offline PR 1127 ).