### PR TITLE
Dev work and updates to compile against the head of Offline

### DIFF
--- a/base/base/TBitset.hh
+++ b/base/base/TBitset.hh
@@ -7,6 +7,10 @@
 #include "TObject.h"
 #include "TBuffer.h"
 
+#include <format>
+#include <iostream>
+#include <string>
+
 class TBitset: public TObject {
 protected:
   Int_t     fNBits;
@@ -46,6 +50,9 @@ public:
 inline Int_t TBitset::GetBit(Int_t I) const {
   Int_t iw = I / 32;
   Int_t ib = I % 32;
+  if(iw >= fNWords) {
+    throw std::runtime_error(std::format("Attempting to read word {} and bit {}, with max {} and set bits {} (input {})", iw, ib, fNWords, fNBits, I));
+  }
   return (fBits[iw] >> ib) & 0x1 ;
 }
 
@@ -56,6 +63,9 @@ inline void TBitset::SetBit(Int_t I) {
 
   Int_t iw = I / 32;
   Int_t ib = I % 32;
+  if(iw >= fNWords) {
+    throw std::runtime_error(std::format("Attempting to set word {} and bit {}, with max {} and set bits {} (input {})", iw, ib, fNWords, fNBits, I));
+  }
   fBits[iw] |= (0x1 << ib);
 }
 
@@ -67,6 +77,9 @@ inline void TBitset::SetBit(Int_t I, int Val) {
   Val = (Val != 0);   // safety
   int iw = I / 32;
   int ib = I % 32;
+  if(iw >= fNWords) {
+    throw std::runtime_error(std::format("Attempting to set word {} and bit {}, with max {} and set bits {} (input {})", iw, ib, fNWords, fNBits, I));
+  }
 
   int mask = Val << ib;
   fBits[iw] = (fBits[iw]^(0x1 << ib)) | mask;

--- a/fcl/default_stn_config.fcl
+++ b/fcl/default_stn_config.fcl
@@ -173,7 +173,7 @@ physics.producers.CprHlxDe50TriggerInfoMerger.doDeepCopy           : 1
 physics.producers.CprHelixUeTriggerInfoMerger.doDeepCopy           : 1
 
 # Turn off MC-matching in the trigger which doesn't work with cloning
-physics.producers.TriTprDeKSFMC : { module_type: NullProducer }
+physics.producers.TrigTprDeKSFMC : { module_type: NullProducer }
 physics.producers.TprTrkDe80m70pD0200TriggerInfoMerger.doDeepCopy  : 1
 physics.producers.TprTrkDe80m70pTriggerInfoMerger.doDeepCopy       : 1
 physics.producers.TprTrkDe50D0200TriggerInfoMerger.doDeepCopy      : 1
@@ -184,6 +184,12 @@ physics.producers.TprHlxDe30pIPAPhiTriggerInfoMerger.doDeepCopy    : 1
 
 physics.producers.TrigMprDeKSFMC : { module_type : NullProducer }
 physics.producers.TrigTprDeKSFMC : { module_type : NullProducer }
+
+# Previous name
+physics.producers.TTAprKSFMC   : { module_type: NullProducer }
+physics.producers.TTCprDeKSFMC : { module_type: NullProducer }
+physics.producers.TTTprDeKSFMC : { module_type: NullProducer }
+physics.producers.TTMprDeKSFMC : { module_type: NullProducer }
 
 #------------------------------------------------------------------------------
 physics.analyzers.StntupleMaker.makeClusters           : 1

--- a/fcl/default_stn_config.fcl
+++ b/fcl/default_stn_config.fcl
@@ -154,7 +154,7 @@ physics.producers.compressRecoMCs.surfaceStepTags : []
 # Clone track/helix/cluster collections specific to each relevant trigger path
 
 # Turn off MC-matching in the trigger which doesn't work with cloning
-physics.producers.TTAprKSFMC : { module_type: NullProducer }
+physics.producers.TrigAprKSFMC : { module_type: NullProducer }
 physics.producers.AprHelixTriggerInfoMerger.doDeepCopy             : 1
 physics.producers.AprTrkDe80m70pD0200TriggerInfoMerger.doDeepCopy  : 1
 physics.producers.AprTrkDe80m70pTriggerInfoMerger.doDeepCopy       : 1
@@ -165,7 +165,7 @@ physics.producers.AprHlx50Hlx30TriggerInfoMerger.doDeepCopy        : 1
 physics.producers.AprHlx50Hlx30TriggerInfoMerger.doDeepCopy        : 1
 
 # Turn off MC-matching in the trigger which doesn't work with cloning
-physics.producers.TTCprDeKSFMC : { module_type: NullProducer }
+physics.producers.TrigCprDeKSFMC : { module_type: NullProducer }
 physics.producers.CprTrkDe80m70pD0200TriggerInfoMerger.doDeepCopy  : 1
 physics.producers.CprTrkDe80m70pTriggerInfoMerger.doDeepCopy       : 1
 physics.producers.CprTrkDe50D0200TriggerInfoMerger.doDeepCopy      : 1
@@ -173,7 +173,7 @@ physics.producers.CprHlxDe50TriggerInfoMerger.doDeepCopy           : 1
 physics.producers.CprHelixUeTriggerInfoMerger.doDeepCopy           : 1
 
 # Turn off MC-matching in the trigger which doesn't work with cloning
-physics.producers.TTTprDeKSFMC : { module_type: NullProducer }
+physics.producers.TriTprDeKSFMC : { module_type: NullProducer }
 physics.producers.TprTrkDe80m70pD0200TriggerInfoMerger.doDeepCopy  : 1
 physics.producers.TprTrkDe80m70pTriggerInfoMerger.doDeepCopy       : 1
 physics.producers.TprTrkDe50D0200TriggerInfoMerger.doDeepCopy      : 1
@@ -182,7 +182,8 @@ physics.producers.TprHlxUe50m30pTriggerInfoMerger.doDeepCopy       : 1
 physics.producers.TprHlxDe30pIPATriggerInfoMerger.doDeepCopy       : 1
 physics.producers.TprHlxDe30pIPAPhiTriggerInfoMerger.doDeepCopy    : 1
 
-physics.producers.TTMprDeKSFMC : { module_type : NullProducer }
+physics.producers.TrigMprDeKSFMC : { module_type : NullProducer }
+physics.producers.TrigTprDeKSFMC : { module_type : NullProducer }
 
 #------------------------------------------------------------------------------
 physics.analyzers.StntupleMaker.makeClusters           : 1

--- a/fcl/default_stn_config.fcl
+++ b/fcl/default_stn_config.fcl
@@ -325,6 +325,6 @@ services.DbService.verbose : 2
 #------------------------------------------------------------------------------
 # Include epilogs to add trigger-MC matching, keep hits, etc.
 #include "Production/JobConfig/digitize/epilog.fcl"
-#include "Production/JobConfig/digitize/OnSpill_epilog.fcl"
+# #include "Production/JobConfig/digitize/OnSpill_epilog.fcl"
 #include "Production/JobConfig/recoMC/epilog.fcl"
 #include "Production/JobConfig/common/epilog.fcl"

--- a/fcl/default_stn_config.fcl
+++ b/fcl/default_stn_config.fcl
@@ -20,6 +20,8 @@ TrigNames_trackSHBlockName    : [ ""                                , ""        
 TrigNames_pidBlockName        : [ ""                                , ""                                   , ""                               ]
 TrigNames_pidCollTag          : [ ""                                , ""                                   , ""                               ]
 TrigNames_trkQualCollTag      : [ ""                                , ""                                   , ""                               ]
+TrigNames_trackTsBlockName    : []
+TrigNames_trackTsCollTag      : []
 
 OfflineNames_timeClusterBlockName   : [ "TimeClusterBlockDe",  "TimeClusterBlockUe", "TimeClusterBlockDmu",  "TimeClusterBlockUmu" ]
 OfflineNames_timeClusterCollTag     : [ "TZClusterFinder"   ,  "TZClusterFinder"   , "TZClusterFinder"    ,  "TZClusterFinder"     ]
@@ -35,6 +37,8 @@ OfflineNames_trackSHBlockName       : [ ""                  ,  ""               
 OfflineNames_pidBlockName           : [ ""                  ,  ""                  , ""                   ,  ""                    ]
 OfflineNames_pidCollTag             : [ ""                  ,  ""                  , ""                   ,  ""                    ]
 OfflineNames_trkQualCollTag         : [ "TrkQualDe"         ,  "TrkQualUe"         , "TrkQualDmu"         ,  "TrkQualUmu"          ]
+OfflineNames_trackTsBlockName       : []
+OfflineNames_trackTsCollTag         : []
 END_PROLOG
 
 # Stntuple prologs
@@ -236,7 +240,11 @@ physics.analyzers.StntupleMaker.trackSHBlockName     : [@sequence::OfflineNames_
 physics.analyzers.StntupleMaker.pidBlockName         : [@sequence::OfflineNames_pidBlockName        , @sequence::TrigNames_pidBlockName        ]
 physics.analyzers.StntupleMaker.pidCollTag           : [@sequence::OfflineNames_pidCollTag          , @sequence::TrigNames_pidCollTag          ]
 physics.analyzers.StntupleMaker.trkQualCollTag       : [@sequence::OfflineNames_trkQualCollTag      , @sequence::TrigNames_trkQualCollTag      ]
-
+physics.analyzers.StntupleMaker.trackTsBlockName     : [@sequence::OfflineNames_trackTsBlockName    , @sequence::TrigNames_trackTsBlockName    ]
+physics.analyzers.StntupleMaker.trackTsCollTag       : [@sequence::OfflineNames_trackTsCollTag      , @sequence::TrigNames_trackTsCollTag      ]
+physics.analyzers.StntupleMaker.trackSeedBlockName   : []
+physics.analyzers.StntupleMaker.trackSeedCollTag     : []
+physics.analyzers.StntupleMaker.helixKsCollTag       : []
 
 #------------------------------------------------------------------------------
 #include "mu2e-trig-config/core/trigDigiInputsEpilog.fcl"

--- a/fcl/default_stn_config.fcl
+++ b/fcl/default_stn_config.fcl
@@ -208,7 +208,7 @@ physics.analyzers.StntupleMaker.tcShCollTag            : [ "makeSH" ]
 physics.analyzers.StntupleMaker.tcChCollTag            : [ "makePH" ]
 physics.analyzers.StntupleMaker.caloHitCollTag         :   "CaloHitMaker"
 physics.analyzers.StntupleMaker.triggerResultsTag      : "TriggerResults::S5Stn"
-physics.analyzers.StntupleMaker.nTriggerBits           : 500
+physics.analyzers.StntupleMaker.nTriggerBits           : 1000
 physics.analyzers.StntupleMaker.strawDigiMCCollTag     : "compressDigiMCs"
 physics.analyzers.StntupleMaker.simpCollTag            : "compressDigiMCs"
 physics.analyzers.StntupleMaker.genpCollTag            : "compressDigiMCs"
@@ -232,6 +232,8 @@ physics.analyzers.StntupleMaker.trackCollTag         : [@sequence::OfflineNames_
 physics.analyzers.StntupleMaker.trackHsBlockName     : [@sequence::OfflineNames_trackHsBlockName    , @sequence::TrigNames_trackHsBlockName    ]
 physics.analyzers.StntupleMaker.tciCollTag           : [@sequence::OfflineNames_tciCollTag          , @sequence::TrigNames_tciCollTag          ]
 physics.analyzers.StntupleMaker.tcmCollTag           : [@sequence::OfflineNames_tcmCollTag          , @sequence::TrigNames_tcmCollTag          ]
+physics.analyzers.StntupleMaker.trackSHBlockName     : [@sequence::OfflineNames_trackSHBlockName    , @sequence::TrigNames_trackSHBlockName    ]
+physics.analyzers.StntupleMaker.pidBlockName         : [@sequence::OfflineNames_pidBlockName        , @sequence::TrigNames_pidBlockName        ]
 physics.analyzers.StntupleMaker.pidCollTag           : [@sequence::OfflineNames_pidCollTag          , @sequence::TrigNames_pidCollTag          ]
 physics.analyzers.StntupleMaker.trkQualCollTag       : [@sequence::OfflineNames_trkQualCollTag      , @sequence::TrigNames_trkQualCollTag      ]
 

--- a/fcl/default_stn_config.fcl
+++ b/fcl/default_stn_config.fcl
@@ -211,6 +211,8 @@ physics.analyzers.StntupleMaker.chCollTag              :   "makePH"
 physics.analyzers.StntupleMaker.tcShCollTag            : [ "makeSH" ]
 physics.analyzers.StntupleMaker.tcChCollTag            : [ "makePH" ]
 physics.analyzers.StntupleMaker.caloHitCollTag         :   "CaloHitMaker"
+physics.analyzers.StntupleMaker.caloClusterMaker       : "CaloClusterMaker"
+physics.analyzers.StntupleMaker.caloClusterMCMaker     : "CaloClusterTruthMatch"
 physics.analyzers.StntupleMaker.triggerResultsTag      : "TriggerResults::S5Stn"
 physics.analyzers.StntupleMaker.nTriggerBits           : 1000
 physics.analyzers.StntupleMaker.strawDigiMCCollTag     : "compressDigiMCs"

--- a/fcl/reco_stn.fcl
+++ b/fcl/reco_stn.fcl
@@ -30,8 +30,8 @@ physics.trigger_paths[203] : "4:RecoDmu"
 physics.trigger_paths[204] : "5:RecoUmu"
 
 # Default output file naming
-services.TFileService.fileName                          : "nts.user.dddddb1s5r0000.ConvAna.001210_00000000.root"
-physics.analyzers.InitStntuple.THistModule.histFileName : "nts.user.dddddb1s5r0000.ConvAna.001210_00000000.stn"
+services.TFileService.fileName                          : "nts.user.dddddb1s5r0000.Stntuple.001210_00000000.root"
+physics.analyzers.InitStntuple.THistModule.histFileName : "nts.user.dddddb1s5r0000.Stntuple.001210_00000000.stn"
 
 # default compression
 physics.analyzers.InitStntuple.THistModule.compressionLevel : 501 # 7

--- a/fcl/reco_stn.fcl
+++ b/fcl/reco_stn.fcl
@@ -8,8 +8,11 @@ process_name : S5Stn
 source       : { module_type : RootInput
     fileNames : ["undefined" ]
     inputCommands : [ "keep  *_*_*_*",
-                      "drop mu2e::HelixSeeds_*_*_*",
-                      "drop mu2e::KalSeeds_*_*_*",
+                      "drop mu2e::HelixSeed*_*_*_*",
+                      "drop mu2e::KalSeed*_*_*_*",
+                      "drop mu2e::KalSeedMCs_*_*_*",
+                      "drop mu2e::IntensityInfo*_*_*_*",
+                      "drop mu2e::RecoCount_*_*_*",
                       "drop mu2e::TriggerInfo_*_*_*",
                       "drop mu2e::CaloClusters_*_*_*",
                       "drop mu2e::TimeClusters_*_*_*",

--- a/gui/TEvdCosmicTrack.cc
+++ b/gui/TEvdCosmicTrack.cc
@@ -36,7 +36,6 @@
 
 #include "Offline/GeometryService/inc/GeometryService.hh"
 #include "Offline/GeometryService/inc/GeomHandle.hh"
-#include "Offline/BTrkData/inc/TrkStrawHit.hh"
 
 #include "Offline/TrackerGeom/inc/Tracker.hh"
 

--- a/gui/TEvdSimParticle.cc
+++ b/gui/TEvdSimParticle.cc
@@ -38,7 +38,6 @@
 
 #include "Offline/GeometryService/inc/GeometryService.hh"
 #include "Offline/GeometryService/inc/GeomHandle.hh"
-#include "Offline/BTrkData/inc/TrkStrawHit.hh"
 
 #include "Offline/TrackerGeom/inc/Tracker.hh"
 
@@ -55,6 +54,9 @@
 #include "Stntuple/print/TAnaDump.hh"
 
 #include "CLHEP/Vector/ThreeVector.h"
+#include "CLHEP/Geometry/Point3D.h"
+#include "BTrk/BbrGeom/HepPoint.h"
+// typedef HepGeom::Point3D<double> HepPoint;
 
 ClassImp(stntuple::TEvdSimParticle)
 
@@ -257,23 +259,23 @@ void TEvdSimParticle::PaintRZ(Option_t* Option) {
   const mu2e::Tracker* tracker = handle.get();
 
   //  const mu2e::Straw  *hstraw, *s, *straw[2];		// first straw
-  const mu2e::Straw  *hstraw, *straw[2];		// first straw
+  const mu2e::Straw  /**hstraw,*/ *straw[2];		// first straw
   
   nplanes = tracker->nPlanes();
 //-----------------------------------------------------------------------------
 // first display track hits - active and not 
 //-----------------------------------------------------------------------------
-  const mu2e::TrkStrawHit  *hit;
+  // const mu2e::TrkStrawHit  *hit;
   //   const TrkHitVector*       hits = &fKrep->hitVector();
 
   int nhits = 0; // NHits();
   for (int i=0; i<nhits; i++) {
-    hit = nullptr; // Hit(i)->TrkStrawHit();
-    rdrift = hit->driftRadius();
+    // hit = nullptr; // Hit(i)->TrkStrawHit();
+    // rdrift = hit->driftRadius();
 
-    hstraw = &hit->straw();
-    zw     = hstraw->getMidPoint().z();
-    rw     = hstraw->getMidPoint().perp();
+    // hstraw = &hit->straw();
+    // zw     = hstraw->getMidPoint().z();
+    // rw     = hstraw->getMidPoint().perp();
 
     fEllipse->SetX1(zw);
     fEllipse->SetY1(rw);
@@ -281,8 +283,8 @@ void TEvdSimParticle::PaintRZ(Option_t* Option) {
     fEllipse->SetR2(rdrift);
     fEllipse->SetFillStyle(3003);
 
-    if (hit->isActive()) fEllipse->SetFillColor(kRed);
-    else                 fEllipse->SetFillColor(kBlue+3);
+    // if (hit->isActive()) fEllipse->SetFillColor(kRed);
+    // else                 fEllipse->SetFillColor(kBlue+3);
 
     fEllipse->PaintEllipse(zw,rw,rdrift,0,0,2*M_PI*180,0);
   }

--- a/gui/TEvdTimeCluster.cc
+++ b/gui/TEvdTimeCluster.cc
@@ -32,7 +32,6 @@
 
 #include "Offline/GeometryService/inc/GeometryService.hh"
 #include "Offline/GeometryService/inc/GeomHandle.hh"
-#include "Offline/BTrkData/inc/TrkStrawHit.hh"
 
 #include "Offline/TrackerGeom/inc/Tracker.hh"
 

--- a/mod/InitClusterBlock.cc
+++ b/mod/InitClusterBlock.cc
@@ -42,12 +42,12 @@
 //-----------------------------------------------------------------------------
 int  StntupleInitMu2eClusterBlock(TStnDataBlock* Block, AbsEvent* Evt, int Mode) {
 
-  constexpr int verbose(10);
+  constexpr int verbose(2);
 
   //  const char*               oname = {"MuratInitClusterBlock"};
-  
+
 //   int                           station, ntrk;
-//   KalRep                        *krep;  
+//   KalRep                        *krep;
 //  double                        h1_fltlen, hn_fltlen, entlen, fitmom_err;
 //   TStnTrack*                    track;
 //   const mu2e::StepPointMC*      step;
@@ -70,8 +70,8 @@ int  StntupleInitMu2eClusterBlock(TStnDataBlock* Block, AbsEvent* Evt, int Mode)
 
   //
   // "makeCaloCluster" would be the process name, "AlgoCLOSESTSeededByENERGY" - the description,
-  // 
-  
+  //
+
   cb->GetModuleLabel("mu2e::CaloClusterCollection",calo_module_label);
   cb->GetDescription("mu2e::CaloClusterCollection",calo_description);
 
@@ -120,7 +120,7 @@ int  StntupleInitMu2eClusterBlock(TStnDataBlock* Block, AbsEvent* Evt, int Mode)
 //-----------------------------------------------------------------------------
 // sort list of pointers such that the most energetic cluster goes the first
 //-----------------------------------------------------------------------------
-  std::sort(list_of_pcl.begin(), list_of_pcl.end(), 
+  std::sort(list_of_pcl.begin(), list_of_pcl.end(),
 	    [](const mu2e::CaloCluster*& lhs, const mu2e::CaloCluster*& rhs)
 	      { return lhs->energyDep() > rhs->energyDep(); } );
 
@@ -154,9 +154,12 @@ int  StntupleInitMu2eClusterBlock(TStnDataBlock* Block, AbsEvent* Evt, int Mode)
   const CLHEP::Hep3Vector       *pos;
   int                           id, ncl;
 
+  constexpr double ROuterRing = 600.; // outer ring where cosmics deposit more energy
+
   double                        sume, sume2, sumy, sumx, sumy2, sumx2, sumxy, qn;
-  double                        e, e1(-1.), e2, emean, e2mean;
-  
+  double                        e, e1(-1.), e2, emean, e2mean, trms, e9, e25, out_ring_e;
+  double                        x_0, y_0, r, max_r;
+
   ncl = list_of_clusters->size();
   for (int i=0; i<ncl; i++) {
     cluster               = cb->NewCluster();
@@ -165,7 +168,11 @@ int  StntupleInitMu2eClusterBlock(TStnDataBlock* Block, AbsEvent* Evt, int Mode)
     cluster->fDiskID      = cl->diskID();
     cluster->fEnergy      = cl->energyDep();
     cluster->fTime        = cl->time();
-    if(verbose > 1) printf("  Cluster %i: E = %.2f, T = %.1f, Disk = %i\n", i, cluster->fEnergy, cluster->fTime, cluster->fDiskID);
+
+    const mu2e::CaloHitPtrVector& list_of_crystals = cluster->fCaloCluster->caloHitsPtrVector();
+    int nh = list_of_crystals.size();
+
+    if(verbose > 1) printf("  Cluster %i: E = %.2f, T = %.1f, Disk = %i, N(crystals) = %i\n", i, cluster->fEnergy, cluster->fTime, cluster->fDiskID, nh);
 
     // If MC info is available, find the corresponding MC cluster
     if(list_of_mc_clusters && mc_assns) {
@@ -185,12 +192,9 @@ int  StntupleInitMu2eClusterBlock(TStnDataBlock* Block, AbsEvent* Evt, int Mode)
                         i, ncl, list_of_mc_clusters->size());
     }
 
-    const mu2e::CaloHitPtrVector& list_of_crystals = cluster->fCaloCluster->caloHitsPtrVector();
-
-    int nh = list_of_crystals.size();
 //-----------------------------------------------------------------------------
 // print individual crystals in local vane coordinate system
-// Y and Z 
+// Y and Z
 //-----------------------------------------------------------------------------
     qn     = 0;
     sume   = 0;
@@ -200,9 +204,20 @@ int  StntupleInitMu2eClusterBlock(TStnDataBlock* Block, AbsEvent* Evt, int Mode)
     sumx2  = 0;
     sumxy  = 0;
     sumy2  = 0;
-    
+
     e2     = 0;
-    
+
+    trms       = 0.; // RMS of hit times
+    e9         = 0.; // Energy in 3x3 around (and including) main crystal
+    e25        = 0.; // Energy in 5x5 around (and including) main crystal
+    out_ring_e = 0.; // Energy in cluster crystals > 600 mm
+    x_0        = 0.; // X of highest energy hit
+    y_0        = 0.; // Y of highest energy hit
+    max_r      = 0.; // Largest distance between main crystal and other crystals
+
+    // main crystal neighbors and next neighbors
+    std::vector<int> neighbors, nneighbors;
+
     for (int ih=0; ih<nh; ih++) {
       hit = &(*list_of_crystals.at(ih));
       e   = hit->energyDep();
@@ -210,27 +225,53 @@ int  StntupleInitMu2eClusterBlock(TStnDataBlock* Block, AbsEvent* Evt, int Mode)
       const mu2e::Crystal* cr = &cal->crystal(id);
 
       pos = &cr->localPosition();
-      
+
       if (e > kMinECrystal) {
-	qn    += 1.;
-	sume  += e;
-	sume2 += e*e;
-	sumx  += e*pos->x();
-	sumy  += e*pos->y();
-	sumx2 += e*pos->x()*pos->x();
-	sumxy += e*pos->x()*pos->y();
-	sumy2 += e*pos->y()*pos->y();
-	
-	if (ih<2) {
-	  e2 += e;
-	  if (ih == 0) e1 = e;
-	}
+        qn    += 1.;
+        sume  += e;
+        sume2 += e*e;
+        sumx  += e*pos->x();
+        sumy  += e*pos->y();
+        sumx2 += e*pos->x()*pos->x();
+        sumxy += e*pos->x()*pos->y();
+        sumy2 += e*pos->y()*pos->y();
+        trms  += std::pow(hit->time() - cluster->fTime, 2);
+        r      = pos->perp();
+
+        if (ih<2) { // most energetic two crystals
+          e2 += e;
+          if (ih == 0) { // most energetic crystal
+            e1 = e;
+            x_0 = pos->x();
+            y_0 = pos->y();
+            neighbors = cr->neighbors();
+            nneighbors = cr->nextNeighbors();
+          }
+        }
+
+        // high radius hits
+        if(r > ROuterRing) out_ring_e += e;
+
+        // energy of direct neighbors of highest energy hit
+        const bool is_neighbor = ih == 0 || std::find(neighbors.begin(), neighbors.end(),
+                                                      hit->crystalID()) != neighbors.end();
+        const bool is_nneighbor = std::find(nneighbors.begin(), nneighbors.end(),
+                                            hit->crystalID()) != nneighbors.end();
+        if(is_neighbor) e9  += e;
+        if(is_nneighbor || is_neighbor) e25 += e;
+
+        // maximum distance between a hit and the main hit
+        if(ih > 0) {
+          const double r = std::sqrt(std::pow(x_0 - pos->x(), 2) +
+                                     std::pow(y_0 - pos->y(), 2));
+          max_r = std::max(max_r, r);
+        }
       }
     }
-    
+
     emean  = sume/(qn+1.e-12);
     e2mean = sume2/(qn+1.e-12);
-    
+
     double xmean, ymean, x2mean, xymean, y2mean, sigxx, sigyy, sigxy, phi;
 
     xmean  = sumx /(sume+1.e-12);
@@ -260,10 +301,10 @@ int  StntupleInitMu2eClusterBlock(TStnDataBlock* Block, AbsEvent* Evt, int Mode)
 //-----------------------------------------------------------------------------
 // make sure that nothing goes into an overflow
 //_____________________________________________________________________________
-    cluster->fFrE1      = e1/(sume+1.e-5);
-    cluster->fFrE2      = e2/(sume+1.e-5);
-    cluster->fSigE1     = sqrt(qn*(e2mean-emean*emean))/(sume+1.e-12);
-    cluster->fSigE2     = sqrt(qn*(e2mean-emean*emean))/(emean+1.e-12);
+    cluster->fFrE1      = (sume  > 0.) ? e1/(sume) : 0.;
+    cluster->fFrE2      = (sume  > 0.) ? e2/(sume) : 0.;
+    cluster->fSigE1     = (sume  > 0.) ? sqrt(qn*(e2mean-emean*emean))/(sume) : 0.;
+    cluster->fSigE2     = (emean > 0.) ? sqrt(qn*(e2mean-emean*emean))/(emean) : 0.;
 //------------------------------------------------------------------------------
 //
 //------------------------------------------------------------------------------
@@ -273,56 +314,76 @@ int  StntupleInitMu2eClusterBlock(TStnDataBlock* Block, AbsEvent* Evt, int Mode)
 
     phi = 0.5*atan2(2*sigxy,sigxx-sigyy);
 
-//     if (sigxx < sigyy) { 
+//     if (sigxx < sigyy) {
 //       phi = phi + M_PI/2.;
 //       cluster->fSigXX = sigyy;
 //       cluster->fSigYY = sigxx;
 //     }
 
-    cluster->fNx   = cos(phi);
-    cluster->fNy   = sin(phi);
+    cluster->fNx        = cos(phi);
+    cluster->fNy        = sin(phi);
 
-    // MC information
+    cluster->fTimeRMS   = std::sqrt(trms);
+    cluster->fMaxR      = max_r;
+    cluster->fE9        = e9;
+    cluster->fE25       = e25;
+    cluster->fOutRingE  = out_ring_e;
+
+    if(verbose > 1) printf("  T(RMS) = %5.3f, Max R = %5.1f, E9 = %5.1f, E25 = %5.1f, Out Ring E = %5.1f, R = %5.1f\n",
+                           cluster->fTimeRMS, cluster->fMaxR,
+                           cluster->fE9, cluster->fE25, cluster->fOutRingE,
+                           std::sqrt(std::pow(cluster->fX, 2) + std::pow(cluster->fY, 2)));
+
+//-----------------------------------------------------------------------------
+// MC information
+//_____________________________________________________________________________
     if(mc_cl) {
       // Map sim --> energy deposited
       std::map<art::Ptr<mu2e::SimParticle>, float> sim_edep;
+      std::map<art::Ptr<mu2e::SimParticle>, float> sim_mom_in;
       float total_time(0.f), total_edep(mc_cl->totalEnergyDep());
       for(const auto& hit : mc_cl->caloHitMCs()) {
+        if(verbose > 2) printf("    Hit: N(edeps) = %2zu\n", hit->energyDeposits().size());
         for(const auto& edep : hit->energyDeposits()) {
           const auto sim = edep.sim();
           const float energy = edep.energyDep();
           sim_edep[sim] += energy;
+          sim_mom_in[sim] = std::max(sim_mom_in[sim], edep.momentumIn());
           total_time += edep.time() * energy / total_edep;
+          if(verbose > 2) printf("      Edep: E = %6.2f, T = %6.1f, mom in = %6.2f, ID = %4lu\n",
+                                 energy, edep.time(), edep.momentumIn(), sim->id().asInt());
         }
       }
       // Find the main sim info
       int main_sim(-1), pdg(0);
-      float edep(-1.f);
+      float edep(-1.f), mom_in(-1.f);
       for(const auto& entry : sim_edep) {
         if(entry.second > edep) {
           main_sim = entry.first->id().asInt();
           pdg = entry.first->pdgId();
           edep = entry.second;
+          mom_in = sim_mom_in[entry.first];
         }
       }
       cluster->fMCSimID   = main_sim;
       cluster->fMCSimPDG  = pdg;
       cluster->fMCSimEDep = edep;
+      cluster->fMCSimMomIn = mom_in;
       cluster->fMCEDep    = total_edep;
       cluster->fMCTime    = total_time;
-      if(verbose > 1) printf("  --> Associated MC cluster found: E = %6.2f, E(G4) = %6.2f, T = %6.1f, N(MC hits) = %2zu, ID = %4i, PDG = %5i, E(sim) = %6.2f\n",
+      if(verbose > 1) printf("  --> Associated MC cluster found: E = %6.2f, E(G4) = %6.2f, T = %6.1f, N(MC hits) = %2zu, ID = %4i, PDG = %5i, E(sim) = %6.2f, Mom in = %6.2f\n",
                              total_edep, mc_cl->totalEnergyDepG4(), total_time,
-                             mc_cl->caloHitMCs().size(), main_sim, pdg, edep);
+                             mc_cl->caloHitMCs().size(), main_sim, pdg, edep, mom_in);
     }
 
 //     unsigned int nm = (*trk_cal_map).size();
 //     for(size_t im=0; i<nm; im++) {
 //       //	KalRepPtr const& trkPtr = fTrkCalMap->at(i).first->trk();
 //       //	const KalRep *  const &trk = *trkPtr;
-      
+
 //       cl = &(*(*trk_cal_map).at(im).second);
-      
-//       if (cl == cluster->fCaloCluster) { 
+
+//       if (cl == cluster->fCaloCluster) {
 // 	cluster->fClosestTrack = fTrackBlock->Track(im);
 // 	break;
 //       }
@@ -332,7 +393,7 @@ int  StntupleInitMu2eClusterBlock(TStnDataBlock* Block, AbsEvent* Evt, int Mode)
 }
 
 //_____________________________________________________________________________
-Int_t StntupleInitMu2eClusterBlockLinks(TStnDataBlock* Block, AbsEvent* AnEvent, int Mode) 
+Int_t StntupleInitMu2eClusterBlockLinks(TStnDataBlock* Block, AbsEvent* AnEvent, int Mode)
 {
   // Mu2e version, do nothing
 
@@ -356,4 +417,3 @@ Int_t StntupleInitMu2eClusterBlockLinks(TStnDataBlock* Block, AbsEvent* AnEvent,
 
   return 0;
 }
-

--- a/mod/InitClusterBlock.cc
+++ b/mod/InitClusterBlock.cc
@@ -42,7 +42,7 @@
 //-----------------------------------------------------------------------------
 int  StntupleInitMu2eClusterBlock(TStnDataBlock* Block, AbsEvent* Evt, int Mode) {
 
-  constexpr int verbose(2);
+  constexpr int verbose(0);
 
   //  const char*               oname = {"MuratInitClusterBlock"};
 

--- a/mod/InitClusterBlock.cc
+++ b/mod/InitClusterBlock.cc
@@ -42,7 +42,7 @@
 //-----------------------------------------------------------------------------
 int  StntupleInitMu2eClusterBlock(TStnDataBlock* Block, AbsEvent* Evt, int Mode) {
 
-  constexpr int verbose(10);
+  constexpr int verbose(0);
 
   //  const char*               oname = {"MuratInitClusterBlock"};
   

--- a/mod/InitClusterBlock.cc
+++ b/mod/InitClusterBlock.cc
@@ -21,9 +21,9 @@
 
 #include "Offline/CalorimeterGeom/inc/DiskCalorimeter.hh"
 
-#include "Offline/RecoDataProducts/inc/KalRepPtrCollection.hh"
+// #include "Offline/RecoDataProducts/inc/KalRepPtrCollection.hh"
 
-#include "Offline/RecoDataProducts/inc/TrackClusterMatch.hh"
+// #include "Offline/RecoDataProducts/inc/TrackClusterMatch.hh"
 
 #include "Offline/MCDataProducts/inc/CaloClusterMC.hh"
 #include "Offline/MCDataProducts/inc/CaloEDepMC.hh"

--- a/mod/InitStntuple_module.cc
+++ b/mod/InitStntuple_module.cc
@@ -280,8 +280,15 @@ int InitStntuple::InitTriggerTable(int RunNumber) {
     trigger_table->AddTrigger(new TStnTrigger( 401, 401,"calo_MVANNCE"                ,1));
     trigger_table->AddTrigger(new TStnTrigger( 402, 402,"calo_cosmic"                 ,1));
     trigger_table->AddTrigger(new TStnTrigger( 420, 420,"calo_RMC"                    ,1));
+    trigger_table->AddTrigger(new TStnTrigger( 425, 425,"calo_cluster_50"             ,1));
+    trigger_table->AddTrigger(new TStnTrigger( 426, 426,"calo_cluster_60"             ,1));
+    trigger_table->AddTrigger(new TStnTrigger( 427, 427,"calo_cluster_70"             ,1));
+    trigger_table->AddTrigger(new TStnTrigger( 428, 428,"calo_cluster_75"             ,1));
+    trigger_table->AddTrigger(new TStnTrigger( 429, 429,"calo_cluster_80"             ,1));
 
     trigger_table->AddTrigger(new TStnTrigger( 500, 500,"cst_TimeCluster"             ,1));
+    trigger_table->AddTrigger(new TStnTrigger( 510, 510,"apr_TC"                      ,1));
+    trigger_table->AddTrigger(new TStnTrigger( 511, 511,"apr_TC_calo"                 ,1));
     trigger_table->AddTrigger(new TStnTrigger( 520, 520,"cst_CosmicTrackSeed"         ,1));
 
     trigger_table->AddTrigger(new TStnTrigger( 600, 600,"minBias_SDCount"             ,1));

--- a/mod/InitStntuple_module.cc
+++ b/mod/InitStntuple_module.cc
@@ -222,9 +222,9 @@ int InitStntuple::InitTriggerTable(int RunNumber) {
     }
     trigger_table->AddTrigger(new TStnTrigger( 410, 410,"minBias_CDCount"             ,1));
 
-  } else if (RunNumber <= 1220) {
+  } else if (RunNumber <= 1450) {
 //-----------------------------------------------------------------------------
-// runs 1211-1220: Trigger bits/names were updated (Oct. 2025)
+// runs 1211-1450: Trigger bits/names were updated (Oct. 2025)
 //-----------------------------------------------------------------------------
     // < 100 is for Offline/processing paths
     trigger_table->AddTrigger(new TStnTrigger(   0,   0,"MixPath"                     ,1));
@@ -269,6 +269,7 @@ int InitStntuple::InitTriggerTable(int RunNumber) {
     trigger_table->AddTrigger(new TStnTrigger( 230, 230,"apr_TrkUe_80m70p"            ,1));
     trigger_table->AddTrigger(new TStnTrigger( 240, 240,"apr_TwoTrkDe_80m70p_D0200"   ,1));
     trigger_table->AddTrigger(new TStnTrigger( 250, 250,"apr_TwoTrkDe_50"             ,1));
+    trigger_table->AddTrigger(new TStnTrigger( 255, 255,"apr_Hlx_50_Hlx_30"           ,1));
     trigger_table->AddTrigger(new TStnTrigger( 260, 260,"apr_TrkDe_50_D0200"          ,1));
     trigger_table->AddTrigger(new TStnTrigger( 265, 265,"apr_Hlx_50"                  ,1));
     trigger_table->AddTrigger(new TStnTrigger( 266, 266,"apr_Hlx_30"                  ,1));

--- a/mod/InitStrawHitBlock.cc
+++ b/mod/InitStrawHitBlock.cc
@@ -12,6 +12,8 @@
 #include "Offline/MCDataProducts/inc/StrawDigiMC.hh"
 #include "Offline/MCDataProducts/inc/StrawGasStep.hh"
 
+#include "BTrk/BbrGeom/HepPoint.h"
+
 #include <vector>
 
 using std::vector ;

--- a/mod/InitTrackBlock.cc
+++ b/mod/InitTrackBlock.cc
@@ -38,13 +38,13 @@
 #include "Offline/RecoDataProducts/inc/KalSeed.hh"
 #include "Offline/RecoDataProducts/inc/TrkFitFlag.hh"
 
-#include "Offline/BTrkData/inc/TrkStrawHit.hh"
-#include "Offline/BTrkData/inc/TrkCaloHit.hh"
-#include "Offline/BTrkData/inc/Doublet.hh"
+
+
+// #include "Offline/BTrkData/inc/Doublet.hh"
 
 #include "Offline/RecoDataProducts/inc/TrkStraw.hh"
-#include "Offline/RecoDataProducts/inc/TrkCaloIntersect.hh"
-#include "Offline/RecoDataProducts/inc/TrackClusterMatch.hh"
+// #include "Offline/RecoDataProducts/inc/TrkCaloIntersect.hh"
+// #include "Offline/RecoDataProducts/inc/TrackClusterMatch.hh"
 
 #include "Offline/MCDataProducts/inc/GenParticle.hh"
 #include "Offline/MCDataProducts/inc/SimParticle.hh"
@@ -62,6 +62,7 @@
 					          // BaBar
 #include "BTrk/ProbTools/ChisqConsistency.hh"
 #include "BTrk/BbrGeom/BbrVectorErr.hh"
+#include "BTrk/BbrGeom/HepPoint.h"
 #include "BTrk/BbrGeom/TrkLineTraj.hh"
 #include "BTrk/TrkBase/TrkPoca.hh"
 #include "BTrk/KalmanTrack/KalHit.hh"
@@ -271,10 +272,10 @@ void StntupleInitTrackBlock::RetrieveData(AbsEvent* AnEvent) {
   if (sdmcHandle.isValid()) list_of_mc_straw_hits = sdmcHandle.product();
   else if(fStrawDigiMCCollTag != "") printf(" InitTrackBlock::%s: StrawDigiMC collection %s not found\n", __func__, fStrawDigiMCCollTag.encode().c_str());
 
-  list_of_extrapolated_tracks = 0;
-  art::Handle<mu2e::TrkCaloIntersectCollection>  texHandle;
-  AnEvent->getByLabel(fTciCollTag,texHandle);
-  if (texHandle.isValid()) list_of_extrapolated_tracks = texHandle.product();
+  // list_of_extrapolated_tracks = 0;
+  // art::Handle<mu2e::TrkCaloIntersectCollection>  texHandle;
+  // AnEvent->getByLabel(fTciCollTag,texHandle);
+  // if (texHandle.isValid()) list_of_extrapolated_tracks = texHandle.product();
 
   list_of_pidp = 0;
   art::Handle<mu2e::PIDProductCollection>  pidpHandle;

--- a/mod/InitTrackBlock.cc
+++ b/mod/InitTrackBlock.cc
@@ -252,10 +252,12 @@ void StntupleInitTrackBlock::RetrieveData(AbsEvent* AnEvent) {
   }
 
   list_of_trk_qual = 0;
-  art::Handle<mu2e::MVAResultCollection> trkQualHandle;
-  AnEvent->getByLabel(fTrkQualCollTag,trkQualHandle);
-  if (trkQualHandle.isValid()) list_of_trk_qual = trkQualHandle.product();
-  else if(fTrkQualCollTag != "") printf(" InitTrackBlock::%s: Track quality collection %s not found\n", __func__, fTrkQualCollTag.encode().c_str());
+  if(fTrkQualCollTag != "") {
+    art::Handle<mu2e::MVAResultCollection> trkQualHandle;
+    AnEvent->getByLabel(fTrkQualCollTag,trkQualHandle);
+    if (trkQualHandle.isValid()) list_of_trk_qual = trkQualHandle.product();
+    else if(fTrkQualCollTag != "") printf(" InitTrackBlock::%s: Track quality collection %s not found\n", __func__, fTrkQualCollTag.encode().c_str());
+  }
 
   fSschColl = 0;
   art::Handle<mu2e::ComboHitCollection> sschcH;
@@ -741,56 +743,8 @@ int StntupleInitTrackBlock::InitDataBlock(TStnDataBlock* Block, AbsEvent* AnEven
   ntrk = (list_of_kffs) ? list_of_kffs->size() : (list_of_kffs_ptrs) ? list_of_kffs_ptrs->size() : 0; 
   nassns = (list_of_kff_assns) ? list_of_kff_assns->size() : 0;
 
-<<<<<<< Updated upstream
   // art::Handle<mu2e::TrackClusterMatchCollection>  tcmH;
   // AnEvent->getByLabel(fTcmCollTag,tcmH);
-=======
-  const mu2e::KalHelixAssns* list_of_kff_assns = nullptr;
-  art::Handle<mu2e::KalHelixAssns> kffAssnsH;
-  AnEvent->getByLabel(fKFFCollTag,kffAssnsH);
-  if (kffAssnsH.isValid()) {
-    list_of_kff_assns = kffAssnsH.product();
-    nassns = list_of_kff_assns->size();
-    if(verbose > 0) printf("%s::%s: KalHelixAssns %15s has %2i associations\n", typeid(*this).name(), __func__, fKFFCollTag.encode().c_str(), nassns);
-    if(nassns != ntrk) printf("%s::%s: KalHelixAssns %15s has a different number of tracks! %i assns %i trks\n",
-                              typeid(*this).name(), __func__, fKFFCollTag.encode().c_str(), nassns, ntrk);
-  } else {
-    if(verbose > 0) printf("%s::%s: KalHelixAssns %s not found!\n", typeid(*this).name(), __func__, fKFFCollTag.encode().c_str());
-  }
-
-  list_of_trk_qual = 0;
-  if(fTrkQualCollTag != "" ) {
-    art::Handle<mu2e::MVAResultCollection> trkQualHandle;
-    AnEvent->getByLabel(fTrkQualCollTag,trkQualHandle);
-    if (trkQualHandle.isValid()) list_of_trk_qual = trkQualHandle.product();
-    else if(fTrkQualCollTag != "") printf(" InitTrackBlock::%s: Track quality collection %s not found\n", __func__, fTrkQualCollTag.encode().c_str());
-  }
-
-  fSschColl = 0;
-  art::Handle<mu2e::ComboHitCollection> sschcH;
-  AnEvent->getByLabel(fSsChCollTag,sschcH);
-  if (sschcH.isValid()) fSschColl = sschcH.product();
-  else printf(" WARNING InitTrackBlock::%s: ComboHitCollection %s not found\n", __func__, fSsChCollTag.encode().c_str());
-
-  list_of_mc_straw_hits = 0;
-  art::Handle<mu2e::StrawDigiMCCollection> sdmcHandle;
-  AnEvent->getByLabel(fStrawDigiMCCollTag,sdmcHandle);
-  if (sdmcHandle.isValid()) list_of_mc_straw_hits = sdmcHandle.product();
-  else if(fStrawDigiMCCollTag != "") printf(" InitTrackBlock::%s: StrawDigiMC collection %s not found\n", __func__, fStrawDigiMCCollTag.encode().c_str());
-
-  list_of_extrapolated_tracks = 0;
-  art::Handle<mu2e::TrkCaloIntersectCollection>  texHandle;
-  AnEvent->getByLabel(fTciCollTag,texHandle);
-  if (texHandle.isValid()) list_of_extrapolated_tracks = texHandle.product();
-
-  art::Handle<mu2e::TrackClusterMatchCollection>  tcmH;
-  AnEvent->getByLabel(fTcmCollTag,tcmH);
-
-  list_of_pidp = 0;
-  art::Handle<mu2e::PIDProductCollection>  pidpHandle;
-  AnEvent->getByLabel(fPIDProductCollTag,pidpHandle);
-  if (pidpHandle.isValid()) list_of_pidp = pidpHandle.product();
->>>>>>> Stashed changes
 
   art::ServiceHandle<mu2e::GeometryService>   geom;
   mu2e::GeomHandle<mu2e::DetectorSystem>      ds;

--- a/mod/InitTrackBlock.cc
+++ b/mod/InitTrackBlock.cc
@@ -741,8 +741,56 @@ int StntupleInitTrackBlock::InitDataBlock(TStnDataBlock* Block, AbsEvent* AnEven
   ntrk = (list_of_kffs) ? list_of_kffs->size() : (list_of_kffs_ptrs) ? list_of_kffs_ptrs->size() : 0; 
   nassns = (list_of_kff_assns) ? list_of_kff_assns->size() : 0;
 
+<<<<<<< Updated upstream
   // art::Handle<mu2e::TrackClusterMatchCollection>  tcmH;
   // AnEvent->getByLabel(fTcmCollTag,tcmH);
+=======
+  const mu2e::KalHelixAssns* list_of_kff_assns = nullptr;
+  art::Handle<mu2e::KalHelixAssns> kffAssnsH;
+  AnEvent->getByLabel(fKFFCollTag,kffAssnsH);
+  if (kffAssnsH.isValid()) {
+    list_of_kff_assns = kffAssnsH.product();
+    nassns = list_of_kff_assns->size();
+    if(verbose > 0) printf("%s::%s: KalHelixAssns %15s has %2i associations\n", typeid(*this).name(), __func__, fKFFCollTag.encode().c_str(), nassns);
+    if(nassns != ntrk) printf("%s::%s: KalHelixAssns %15s has a different number of tracks! %i assns %i trks\n",
+                              typeid(*this).name(), __func__, fKFFCollTag.encode().c_str(), nassns, ntrk);
+  } else {
+    if(verbose > 0) printf("%s::%s: KalHelixAssns %s not found!\n", typeid(*this).name(), __func__, fKFFCollTag.encode().c_str());
+  }
+
+  list_of_trk_qual = 0;
+  if(fTrkQualCollTag != "" ) {
+    art::Handle<mu2e::MVAResultCollection> trkQualHandle;
+    AnEvent->getByLabel(fTrkQualCollTag,trkQualHandle);
+    if (trkQualHandle.isValid()) list_of_trk_qual = trkQualHandle.product();
+    else if(fTrkQualCollTag != "") printf(" InitTrackBlock::%s: Track quality collection %s not found\n", __func__, fTrkQualCollTag.encode().c_str());
+  }
+
+  fSschColl = 0;
+  art::Handle<mu2e::ComboHitCollection> sschcH;
+  AnEvent->getByLabel(fSsChCollTag,sschcH);
+  if (sschcH.isValid()) fSschColl = sschcH.product();
+  else printf(" WARNING InitTrackBlock::%s: ComboHitCollection %s not found\n", __func__, fSsChCollTag.encode().c_str());
+
+  list_of_mc_straw_hits = 0;
+  art::Handle<mu2e::StrawDigiMCCollection> sdmcHandle;
+  AnEvent->getByLabel(fStrawDigiMCCollTag,sdmcHandle);
+  if (sdmcHandle.isValid()) list_of_mc_straw_hits = sdmcHandle.product();
+  else if(fStrawDigiMCCollTag != "") printf(" InitTrackBlock::%s: StrawDigiMC collection %s not found\n", __func__, fStrawDigiMCCollTag.encode().c_str());
+
+  list_of_extrapolated_tracks = 0;
+  art::Handle<mu2e::TrkCaloIntersectCollection>  texHandle;
+  AnEvent->getByLabel(fTciCollTag,texHandle);
+  if (texHandle.isValid()) list_of_extrapolated_tracks = texHandle.product();
+
+  art::Handle<mu2e::TrackClusterMatchCollection>  tcmH;
+  AnEvent->getByLabel(fTcmCollTag,tcmH);
+
+  list_of_pidp = 0;
+  art::Handle<mu2e::PIDProductCollection>  pidpHandle;
+  AnEvent->getByLabel(fPIDProductCollTag,pidpHandle);
+  if (pidpHandle.isValid()) list_of_pidp = pidpHandle.product();
+>>>>>>> Stashed changes
 
   art::ServiceHandle<mu2e::GeometryService>   geom;
   mu2e::GeomHandle<mu2e::DetectorSystem>      ds;

--- a/mod/InitTrackBlock_KK.cc
+++ b/mod/InitTrackBlock_KK.cc
@@ -32,12 +32,12 @@
 #include "Offline/CalorimeterGeom/inc/Calorimeter.hh"
 #include "Offline/CalorimeterGeom/inc/DiskCalorimeter.hh"
 
-#include "Offline/BTrkData/inc/TrkStrawHit.hh"
-#include "Offline/BTrkData/inc/TrkCaloHit.hh"
-#include "Offline/BTrkData/inc/Doublet.hh"
 
-#include "Offline/RecoDataProducts/inc/TrkCaloIntersect.hh"
-#include "Offline/RecoDataProducts/inc/TrackClusterMatch.hh"
+
+// #include "Offline/BTrkData/inc/Doublet.hh"
+
+// #include "Offline/RecoDataProducts/inc/TrkCaloIntersect.hh"
+// #include "Offline/RecoDataProducts/inc/TrackClusterMatch.hh"
 #include "Offline/RecoDataProducts/inc/HelixSeed.hh"
 #include "Offline/RecoDataProducts/inc/KalSeed.hh"
 

--- a/mod/InitTrackStrawHitBlock.cc
+++ b/mod/InitTrackStrawHitBlock.cc
@@ -13,7 +13,7 @@
 
 #include "Offline/RecoDataProducts/inc/KalSeed.hh"
 
-#include "Offline/BTrkData/inc/TrkStrawHit.hh"
+
 
 #include "Offline/MCDataProducts/inc/SimParticle.hh"
 #include "Offline/MCDataProducts/inc/StrawGasStep.hh"
@@ -21,6 +21,8 @@
 
 #include "Offline/GeometryService/inc/GeomHandle.hh"
 #include "Offline/TrackerGeom/inc/Tracker.hh"
+
+#include "BTrk/BbrGeom/HepPoint.h"
 
 namespace stntuple {
 //-----------------------------------------------------------------------------
@@ -124,7 +126,8 @@ int InitTrackStrawHitBlock::InitDataBlock(TStnDataBlock* Block, AbsEvent* _Event
       nhtot += nhits;
 
       for (int ih=0; ih<nhits; ih++) {
-	const mu2e::TrkStrawHitSeed* tsh = static_cast<const mu2e::TrkStrawHitSeed*> (&ks_hits->at(ih));
+	// const mu2e::TrkStrawHitSeed* tsh = static_cast<const mu2e::TrkStrawHitSeed*> (&ks_hits->at(ih));
+	const auto* tsh = &ks_hits->at(ih);
 	int ind = tsh->index(); // in the list of straw hits
 	sh      = &sh_coll->at(ind);
 
@@ -162,12 +165,12 @@ int InitTrackStrawHitBlock::InitDataBlock(TStnDataBlock* Block, AbsEvent* _Event
 	  const CLHEP::Hep3Vector& v2 = step->position();
 	  HepPoint    p2(v2.x(),v2.y(),v2.z());
 	      
-	  TrkLineTraj trstraw(p1,straw->getDirection()  ,0.,0.);
-	  TrkLineTraj trstep (p2,step->momvec().unit(),0.,0.);
+	  // TrkLineTraj trstraw(p1,straw->getDirection()  ,0.,0.);
+	  // TrkLineTraj trstep (p2,step->momvec().unit(),0.,0.);
 	      
-	  TrkPoca poca(trstep, 0., trstraw, 0.);
+	  // TrkPoca poca(trstep, 0., trstraw, 0.);
 	
-	  mcdoca = poca.doca();
+	  // mcdoca = poca.doca();
 	}
 	else {
 	  pdg_id        = -1;

--- a/mod/InitTriggerBlock.cc
+++ b/mod/InitTriggerBlock.cc
@@ -52,7 +52,7 @@ int StntupleInitTriggerBlock::InitDataBlock(TStnDataBlock* Block, AbsEvent* Even
     // block->fPaths.Init(nbits);
 
     for (int i=0; i<block->fNPaths; i++) {
-      const std::string& name = trn.getTrigPathName(i);
+      const std::string& name = trn.getTrigPathNameByIndex(i);
 
       if (trn.accepted(name)) {
         //-----------------------------------------------------------------------------
@@ -62,7 +62,7 @@ int StntupleInitTriggerBlock::InitDataBlock(TStnDataBlock* Block, AbsEvent* Even
 
         int trig_bit = -1;
         try {
-          trig_bit = trn.getTrigBit(name);
+          trig_bit = trn.getTrigBitByName(name);
         } catch (...) {}
         // ttbl->GetListOfTriggers(name.data(),&list);
         ttbl->GetListOfTriggers("",&list); // check against all triggers

--- a/mod/SConscript
+++ b/mod/SConscript
@@ -75,7 +75,6 @@ def local_build():
                  'mu2e_DbService',
                  'mu2e_DbTables',
                  'mu2e_CaloMC',
-                 'mu2e_BTrkData',
                  babarlibs,
                  'CLHEP',
                  'art_Framework_Core',

--- a/mod/StntupleMaker_module.cc
+++ b/mod/StntupleMaker_module.cc
@@ -169,6 +169,7 @@ protected:
 
   string                   fCaloCrystalHitMaker;
   string                   fCaloClusterMaker;
+  string                   fCaloClusterMCMaker;
 //-----------------------------------------------------------------------------
 // initialization of various data blocks
 //-----------------------------------------------------------------------------
@@ -321,6 +322,7 @@ StntupleMaker::StntupleMaker(fhicl::ParameterSet const& PSet):
 
   , fCaloCrystalHitMaker     (PSet.get<string>        ("caloCrystalHitsMaker"))
   , fCaloClusterMaker        (PSet.get<string>        ("caloClusterMaker"    ))
+  , fCaloClusterMCMaker      (PSet.get<string>        ("caloClusterMCMaker", ""))
 
   , fGenId((PSet.get<std::string>("genId","unknown") == "unknown") ? GenId::findByName (PSet.get<std::string>("genId")) : GenId::unknown)
   , fPdgId                   (PSet.get<int>           ("pdgId"               ))
@@ -540,6 +542,7 @@ void StntupleMaker::beginJob() {
 				     compression_level);
     if (db) {
       db->AddCollName("mu2e::CaloClusterCollection",fCaloClusterMaker.data());
+      db->AddCollName("mu2e::CaloClusterMCCollection",fCaloClusterMCMaker.data());
       SetResolveLinksMethod("ClusterBlock",StntupleInitMu2eClusterBlockLinks);
     }
   }

--- a/mod/StntupleMaker_module.cc
+++ b/mod/StntupleMaker_module.cc
@@ -375,6 +375,41 @@ StntupleMaker::StntupleMaker(fhicl::ParameterSet const& PSet):
 
   fFolder->Add(fDarHandle);
 
+  // Validate inputs
+
+  // Tracks
+  const size_t n_track_blocks = fTrackBlockName.size();
+  if(fTrackCollTag.size() != n_track_blocks)
+    throw std::runtime_error("fTrackCollTag list size doesn't match track block list size");
+  if(fTrackHsBlockName.size() != n_track_blocks)
+    throw std::runtime_error("fTrackHsBlockName list size doesn't match track block list size");
+  if(fTciCollTag.size() != n_track_blocks)
+    throw std::runtime_error("fTciCollTag list size doesn't match track block list size");
+  if(fTcmCollTag.size() != n_track_blocks)
+    throw std::runtime_error("fTcmCollTag list size doesn't match track block list size");
+  if(fTrkQualCollTag.size() != n_track_blocks)
+    throw std::runtime_error("fTrkQualCollTag list size doesn't match track block list size");
+  if(fPidCollTag.size() != n_track_blocks)
+    throw std::runtime_error("fPidCollTag list size doesn't match track block list size");
+  if(fMakePid && fPidBlockName.size() != n_track_blocks)
+    throw std::runtime_error("fPidBlockName list size doesn't match track block list size");
+  if(!fTrackTsBlockName.empty() && fTrackTsBlockName.size() != n_track_blocks)
+    throw std::runtime_error("fTrackTsBlockName list size doesn't match track block list size");
+  if(fTrackTsBlockName.size() != fTrackTsCollTag.size())
+    throw std::runtime_error("fTrackTsBlockName list size doesn't match coll tag list size");
+
+  // Helices
+  const size_t n_helix_blocks = fHelixBlockName.size();
+  if(fHelixSeedCollTag.size() != n_helix_blocks)
+    throw std::runtime_error("fHelixSeedCollTag list size doesn't match helix block list size");
+  if(fTClBlockName.size() != n_helix_blocks)
+    throw std::runtime_error("fTClBlockName list size doesn't match helix block list size");
+  if(!fKsfBlockName.empty() && fKsfBlockName.size() != n_helix_blocks)
+    throw std::runtime_error("fKsfBlockName list size doesn't match helix block list size");
+  if(fKsfBlockName.size() != fHelixKsCollTag.size())
+    throw std::runtime_error("fKsfBlockName list size doesn't match helix KS coll tag list size");
+
+
 }
 
 

--- a/mod/StntupleMaker_module.cc
+++ b/mod/StntupleMaker_module.cc
@@ -68,7 +68,7 @@
 #include "Stntuple/base/TNamedHandle.hh"
 #include "Stntuple/alg/TStntuple.hh"
 
-#include "Offline/TrkReco/inc/DoubletAmbigResolver.hh"
+// #include "Offline/TrkReco/inc/DoubletAmbigResolver.hh"
 #include "Offline/MCDataProducts/inc/GenId.hh"
 #include "Offline/RecoDataProducts/inc/HelixSeed.hh"
 // #include "TrkDiag/inc/KalDiag.hh"
@@ -209,9 +209,9 @@ protected:
 
   TNamed*                  fVersion;
 
-  TNamedHandle*            fDarHandle;
+  // TNamedHandle*            fDarHandle;
 
-  DoubletAmbigResolver*    fDar;
+  // DoubletAmbigResolver*    fDar;
 
 //------------------------------------------------------------------------------
 // function members
@@ -370,12 +370,12 @@ StntupleMaker::StntupleMaker(fhicl::ParameterSet const& PSet):
 
   fInitTimeClusterBlock = new TObjArray();
   fInitTimeClusterBlock->SetOwner(kTRUE);
-  fDar                  = new DoubletAmbigResolver (PSet.get<fhicl::ParameterSet>("DoubletAmbigResolver"),0.,0,0);
-  fDarHandle            = new TNamedHandle("DarHandle",fDar);
+  // fDar                  = new DoubletAmbigResolver (PSet.get<fhicl::ParameterSet>("DoubletAmbigResolver"),0.,0,0);
+  // fDarHandle            = new TNamedHandle("DarHandle",fDar);
   // fKalDiag              = new KalDiag     (PSet.get<fhicl::ParameterSet>("KalDiag",fhicl::ParameterSet()));
   // fKalDiagHandle        = new TNamedHandle("KalDiagHandle"      ,fKalDiag);
 
-  fFolder->Add(fDarHandle);
+  // fFolder->Add(fDarHandle);
 
   // Validate inputs
 
@@ -417,8 +417,8 @@ StntupleMaker::StntupleMaker(fhicl::ParameterSet const& PSet):
 
 //------------------------------------------------------------------------------
 StntupleMaker::~StntupleMaker() {
-  delete fDar;
-  delete fDarHandle;
+  // delete fDar;
+  // delete fDarHandle;
   delete fVersion;
 
   if (fInitCrvPulseBlock  ) delete fInitCrvPulseBlock;
@@ -793,7 +793,7 @@ void StntupleMaker::beginJob() {
       init_block->SetTcmCollTag         (fTcmCollTag[i]);
       init_block->SetTrkQualCollTag     (fTrkQualCollTag[i]);
 
-      init_block->SetDoubletAmbigResolver(fDar);
+      // init_block->SetDoubletAmbigResolver(fDar);
 
       init_block->fVerbose = fTrackVerbose;
 

--- a/mod/mod/InitTrackBlock.hh
+++ b/mod/mod/InitTrackBlock.hh
@@ -13,14 +13,14 @@
 
 #ifndef __CINT__
 
-#include "Offline/TrkReco/inc/DoubletAmbigResolver.hh"
+// #include "Offline/TrkReco/inc/DoubletAmbigResolver.hh"
 #include "Offline/TrackerGeom/inc/Tracker.hh"
 #include "Offline/RecoDataProducts/inc/AlgorithmID.hh"
 #include "Offline/RecoDataProducts/inc/ComboHit.hh"
 #include "Offline/RecoDataProducts/inc/KalSeed.hh"
 #include "Offline/RecoDataProducts/inc/HelixSeed.hh"
 #include "Offline/RecoDataProducts/inc/KalSeedAssns.hh"
-#include "Offline/RecoDataProducts/inc/TrkCaloIntersect.hh"
+// #include "Offline/RecoDataProducts/inc/TrkCaloIntersect.hh"
 #include "Offline/RecoDataProducts/inc/MVAResult.hh"
 #include "Offline/RecoDataProducts/inc/PIDProduct.hh"
 #include "Offline/RecoDataProducts/inc/TrkStraw.hh"
@@ -31,7 +31,7 @@
 #else
 namespace mu2e {
   class AlgorithmIDCollection;
-  class DoubletAmbigResolver;
+  // class DoubletAmbigResolver;
   class Tracker;
   class ComboHitCollection;
   class KalSeedCollection;
@@ -75,13 +75,13 @@ public:
   const mu2e::MVAResultCollection*         list_of_trk_qual           ;
   const mu2e::StrawDigiMCCollection*       list_of_mc_straw_hits      ;
   const mu2e::ComboHitCollection*          fSschColl                  ;
-  const mu2e::TrkCaloIntersectCollection*  list_of_extrapolated_tracks;
+  // const mu2e::TrkCaloIntersectCollection*  list_of_extrapolated_tracks;
   const mu2e::PIDProductCollection*        list_of_pidp               ;
 
   const mu2e::Tracker*                     tracker;
   ZMap_t                                   zmap;
 
-  mu2e::DoubletAmbigResolver*              _dar;
+  // mu2e::DoubletAmbigResolver*              _dar;
 //-----------------------------------------------------------------------------
 // functions
 //-----------------------------------------------------------------------------
@@ -99,7 +99,7 @@ public:
   void   SetTrkQualCollTag          (std::string& Tag) { fTrkQualCollTag       = art::InputTag(Tag); }
   void   SetTrackTsCollTag          (std::string& Tag) { fTrackTsCollTag       = art::InputTag(Tag); }
 
-  void   SetDoubletAmbigResolver    (mu2e::DoubletAmbigResolver* Dar) { _dar   = Dar; }
+  // void   SetDoubletAmbigResolver    (mu2e::DoubletAmbigResolver* Dar) { _dar   = Dar; }
 
   void   SetTrackTsBlockName        (const char* Name) { fTrackTsBlockName     = Name; }
   void   SetTrackHsBlockName        (const char* Name) { fTrackHsBlockName     = Name; }

--- a/mod/mod/MuHitDisplay_module.hh
+++ b/mod/mod/MuHitDisplay_module.hh
@@ -40,7 +40,7 @@
 #include "Offline/RecoDataProducts/inc/CrvRecoPulse.hh"
 #include "Offline/RecoDataProducts/inc/TimeCluster.hh"
 
-#include "Offline/BTrkData/inc/TrkStrawHit.hh"
+
 
 class TApplication;
 

--- a/obj/TStnCluster.cc
+++ b/obj/TStnCluster.cc
@@ -91,14 +91,17 @@ void TStnCluster::ReadV1(TBuffer &R__b) {
   fMCSimID       =  -1;     // added in V3
   fMCSimPDG      =  0 ;     // added in V3
   fMCSimEDep     = -1.;     // added in V3
+  fMCEDep        = -1.;     // added in V3
+  fMCTime        =  0.;     // added in V3
 }
 
 //-----------------------------------------------------------------------------
 void TStnCluster::Streamer(TBuffer& R__b) {
-  int nwi, nwf;
+  int nwi, nwf, nwf2;
 
   nwi = (int*  ) &fInt   - &fNumber + kNFreeInts;
   nwf = (float*) &fFloat - &fX      + kNFreeFloats ;
+  nwf2= (float*) &fFloat2- &fMCTime + kNFreeFloats2;
 
   if (R__b.IsReading()) {
     Version_t R__v = R__b.ReadVersion(); 
@@ -112,14 +115,19 @@ void TStnCluster::Streamer(TBuffer& R__b) {
         fMCSimID       = -1 ;
         fMCSimPDG      =  0 ;
         fMCSimEDep     = -1.;
+        fMCEDep        = -1.;
+        fMCTime        =  0.;
+      } else {
+        R__b.ReadFastArray(&fMCTime,nwf2); // Extra float region added in V3
       }
     }
   }
   else {
     R__b.WriteVersion(TStnCluster::IsA());
 
-    R__b.WriteFastArray(&fNumber,nwi);
-    R__b.WriteFastArray(&fX     ,nwf);
+    R__b.WriteFastArray(&fNumber,nwi );
+    R__b.WriteFastArray(&fX     ,nwf );
+    R__b.WriteFastArray(&fMCTime,nwf2);
   }
 }
 
@@ -133,6 +141,8 @@ TStnCluster::TStnCluster(Int_t Number) {
   fMCSimID      = -1;
   fMCSimPDG     =  0;
   fMCSimEDep    = -1.f;
+  fMCEDep       = -1.f;
+  fMCTime       =  0.f;
 }
 
 
@@ -147,6 +157,8 @@ void TStnCluster::Clear(Option_t* opt) {
   fMCSimID      = -1;
   fMCSimPDG     =  0;
   fMCSimEDep    = -1.f;
+  fMCEDep       = -1.f;
+  fMCTime       =  0.f;
 }
 
 //-----------------------------------------------------------------------------

--- a/obj/TStnCluster.cc
+++ b/obj/TStnCluster.cc
@@ -88,6 +88,9 @@ void TStnCluster::ReadV1(TBuffer &R__b) {
   fSigYY         = -1.;
   fNx            =  1.;     // cluster direction
   fNy            =  0.;
+  fMCSimID       =  -1;     // added in V3
+  fMCSimPDG      =  0 ;     // added in V3
+  fMCSimEDep     = -1.;     // added in V3
 }
 
 //-----------------------------------------------------------------------------
@@ -102,9 +105,14 @@ void TStnCluster::Streamer(TBuffer& R__b) {
 
     if (R__v == 1) ReadV1(R__b);
     else {
-					// current version: V2
+					// current version: V3
       R__b.ReadFastArray(&fNumber,nwi);
       R__b.ReadFastArray(&fX     ,nwf);
+      if(R__v < 3) { // added in version 3
+        fMCSimID       = -1 ;
+        fMCSimPDG      =  0 ;
+        fMCSimEDep     = -1.;
+      }
     }
   }
   else {
@@ -122,6 +130,9 @@ TStnCluster::TStnCluster(Int_t Number) {
   fNumber       = Number;
   fCaloCluster  = 0;
   fClosestTrack = 0;
+  fMCSimID      = -1;
+  fMCSimPDG     =  0;
+  fMCSimEDep    = -1.f;
 }
 
 
@@ -133,6 +144,9 @@ TStnCluster::~TStnCluster() {
 //-----------------------------------------------------------------------------
 void TStnCluster::Clear(Option_t* opt) {
   Error("Print", "Not implemented yet");
+  fMCSimID      = -1;
+  fMCSimPDG     =  0;
+  fMCSimEDep    = -1.f;
 }
 
 //-----------------------------------------------------------------------------

--- a/obj/TStnCluster.cc
+++ b/obj/TStnCluster.cc
@@ -130,7 +130,7 @@ void TStnCluster::Streamer(TBuffer& R__b) {
         fMCEDep        = -1.;
         fMCTime        =  0.;
       } else {
-        R__b.ReadFastArray(&fMCTime,nwf2); // Extra float region added in V3
+        R__b.ReadFastArray(&fE9,nwf2); // Extra float region added in V3
       }
     }
   }
@@ -139,7 +139,7 @@ void TStnCluster::Streamer(TBuffer& R__b) {
 
     R__b.WriteFastArray(&fNumber,nwi );
     R__b.WriteFastArray(&fX     ,nwf );
-    R__b.WriteFastArray(&fMCTime,nwf2);
+    R__b.WriteFastArray(&fE9    ,nwf2);
   }
 }
 

--- a/obj/TStnCluster.cc
+++ b/obj/TStnCluster.cc
@@ -88,9 +88,15 @@ void TStnCluster::ReadV1(TBuffer &R__b) {
   fSigYY         = -1.;
   fNx            =  1.;     // cluster direction
   fNy            =  0.;
+  fTimeRMS       =  0.;     // added in V3
+  fMaxR          =  0.;     // added in V3
+  fE9            =  0.;     // added in V3
+  fE25           =  0.;     // added in V3
+  fOutRingE      =  0.;     // added in V3
   fMCSimID       =  -1;     // added in V3
   fMCSimPDG      =  0 ;     // added in V3
   fMCSimEDep     = -1.;     // added in V3
+  fMCSimMomIn    = -1.;     // added in V3
   fMCEDep        = -1.;     // added in V3
   fMCTime        =  0.;     // added in V3
 }
@@ -112,9 +118,15 @@ void TStnCluster::Streamer(TBuffer& R__b) {
       R__b.ReadFastArray(&fNumber,nwi);
       R__b.ReadFastArray(&fX     ,nwf);
       if(R__v < 3) { // added in version 3
+        fTimeRMS       =  0.;
+        fMaxR          =  0.;
+        fE9            =  0.;
+        fE25           =  0.;
+        fOutRingE      =  0.;
         fMCSimID       = -1 ;
         fMCSimPDG      =  0 ;
         fMCSimEDep     = -1.;
+        fMCSimMomIn    = -1.;
         fMCEDep        = -1.;
         fMCTime        =  0.;
       } else {
@@ -138,9 +150,15 @@ TStnCluster::TStnCluster(Int_t Number) {
   fNumber       = Number;
   fCaloCluster  = 0;
   fClosestTrack = 0;
+  fTimeRMS      =  0.f;
+  fMaxR         =  0.f;
+  fE9           =  0.f;
+  fE25          =  0.f;
+  fOutRingE     =  0.f;
   fMCSimID      = -1;
   fMCSimPDG     =  0;
   fMCSimEDep    = -1.f;
+  fMCSimMomIn   = -1.f;
   fMCEDep       = -1.f;
   fMCTime       =  0.f;
 }
@@ -154,6 +172,11 @@ TStnCluster::~TStnCluster() {
 //-----------------------------------------------------------------------------
 void TStnCluster::Clear(Option_t* opt) {
   Error("Print", "Not implemented yet");
+  fTimeRMS      =  0.f;
+  fMaxR         =  0.f;
+  fE9           =  0.f;
+  fE25          =  0.f;
+  fOutRingE     =  0.f;
   fMCSimID      = -1;
   fMCSimPDG     =  0;
   fMCSimEDep    = -1.f;

--- a/obj/TStnTrack.cc
+++ b/obj/TStnTrack.cc
@@ -40,7 +40,7 @@ void TStnTrack::ReadV4(TBuffer &R__b) {
     float        fNyTrk;
     float        fNzTrk;
     const mu2e::CaloCluster*       fCluster;
-    const mu2e::TrkToCaloExtrapol* fExtrk;
+    // const mu2e::TrkToCaloExtrapol* fExtrk;
   };
 
   struct TStnTrackDataV4_t {
@@ -223,7 +223,7 @@ void TStnTrack::ReadV4(TBuffer &R__b) {
       fDisk[i].fDr       = -1.e6       ; // undefined before V10
       fDisk[i].fSInt     = -1.e6       ; // undefined before V10
       fDisk[i].fCluster  = NULL;
-      fDisk[i].fExtrk    = NULL;
+      // fDisk[i].fExtrk    = NULL;
     }
   }
 
@@ -261,7 +261,7 @@ void TStnTrack::ReadV5(TBuffer &R__b) {
     float        fChi2Match;		// track-cluster match chi&^2
     float        fPath;
     const mu2e::CaloCluster*       fCluster;
-    const mu2e::TrkToCaloExtrapol* fExtrk;
+    // const mu2e::TrkToCaloExtrapol* fExtrk;
   };
 
   struct TStnTrackDataV5_t {
@@ -453,7 +453,7 @@ void TStnTrack::ReadV5(TBuffer &R__b) {
       fDisk[i].fDr       = -1.e6       ; // undefined before V10
       fDisk[i].fSInt     = -1.e6       ; // undefined before V10
       fDisk[i].fCluster  = NULL        ;
-      fDisk[i].fExtrk    = NULL        ;
+      // fDisk[i].fExtrk    = NULL        ;
     }
   }
 
@@ -495,7 +495,7 @@ void TStnTrack::ReadV6(TBuffer &R__b) {
     float        fPath;			// track path in the disk
     float        fIntDepth;             // assumed interaction depth, added in V6;
     const mu2e::CaloCluster*       fCluster;
-    const mu2e::TrkToCaloExtrapol* fExtrk;
+    // const mu2e::TrkToCaloExtrapol* fExtrk;
   };
 
   struct TStnTrackDataV6_t {
@@ -688,7 +688,7 @@ void TStnTrack::ReadV6(TBuffer &R__b) {
       fDisk[i].fDr       = -1.e6       ; // undefined before V10
       fDisk[i].fSInt     = -1.e6       ; // undefined before V10
       fDisk[i].fCluster  = NULL        ;
-      fDisk[i].fExtrk    = NULL        ;
+      // fDisk[i].fExtrk    = NULL        ;
     }
   }
 
@@ -731,7 +731,7 @@ void TStnTrack::ReadV7(TBuffer &R__b) {
     float        fPath;			// track path in the disk
     float        fIntDepth;             // assumed interaction depth, added in V6;
     const mu2e::CaloCluster*       fCluster;
-    const mu2e::TrkToCaloExtrapol* fExtrk;
+    // const mu2e::TrkToCaloExtrapol* fExtrk;
   };
 
   struct TStnTrackDataV7_t {
@@ -926,7 +926,7 @@ void TStnTrack::ReadV7(TBuffer &R__b) {
       fDisk[i].fDr       = -1.e6       ; // undefined before V10
       fDisk[i].fSInt     = -1.e6       ; // undefined before V10
       fDisk[i].fCluster  = NULL        ;
-      fDisk[i].fExtrk    = NULL        ;
+      // fDisk[i].fExtrk    = NULL        ;
     }
   }
 
@@ -970,7 +970,7 @@ void TStnTrack::ReadV8(TBuffer &R__b) {
     float        fPath;			// track path in the disk
     float        fIntDepth;             // assumed interaction depth, added in V6;
     const mu2e::CaloCluster*       fCluster;
-    const mu2e::TrkToCaloExtrapol* fExtrk;
+    // const mu2e::TrkToCaloExtrapol* fExtrk;
   };
 
   struct TStnTrackDataV8_t {
@@ -1168,7 +1168,7 @@ void TStnTrack::ReadV8(TBuffer &R__b) {
       fDisk[i].fSInt     = -1;           // undefined before V10
 
       fDisk[i].fCluster  = NULL        ;
-      fDisk[i].fExtrk    = NULL        ;
+      // fDisk[i].fExtrk    = NULL        ;
     }
   }
 
@@ -1209,7 +1209,7 @@ void TStnTrack::ReadV9(TBuffer &R__b) {
     float        fPath;			// track path in the disk
     float        fIntDepth;             // assumed interaction depth, added in V6;
     const mu2e::CaloCluster*       fCluster;
-    const mu2e::TrkToCaloExtrapol* fExtrk;
+    // const mu2e::TrkToCaloExtrapol* fExtrk;
   };
 
   struct TStnTrackDataV9_t {
@@ -1411,7 +1411,7 @@ void TStnTrack::ReadV9(TBuffer &R__b) {
       fDisk[i].fSInt     = -1;           // added in V10
 
       fDisk[i].fCluster  = NULL        ;
-      fDisk[i].fExtrk    = NULL        ;
+      // fDisk[i].fExtrk    = NULL        ;
     }
   }
 
@@ -1454,7 +1454,7 @@ void TStnTrack::ReadV10(TBuffer &R__b) {
     float        fDr;                   // ** added in V10: DR(cluster-track), signed
     float        fSInt;                 // ** added in V10: interaction length, calculated
     const mu2e::CaloCluster*       fCluster;
-    const mu2e::TrkToCaloExtrapol* fExtrk;
+    // const mu2e::TrkToCaloExtrapol* fExtrk;
   };
 
   struct TStnTrackDataV10_t {
@@ -1655,7 +1655,7 @@ void TStnTrack::ReadV10(TBuffer &R__b) {
       fDisk[i].fSInt     = disk.fSInt  ; // ** added in V10
 
       fDisk[i].fCluster  = NULL        ;
-      fDisk[i].fExtrk    = NULL        ;
+      // fDisk[i].fExtrk    = NULL        ;
     }
   }
 
@@ -1888,7 +1888,7 @@ void TStnTrack::Clear(Option_t* Opt) {
   fKalRep[2] = 0;
   fKalRep[3] = 0;
 
-  fExtrk              = NULL;
+  // fExtrk              = NULL;
   fClosestCaloCluster = NULL;
   fCluster            = NULL;
 
@@ -1935,7 +1935,7 @@ void TStnTrack::Clear(Option_t* Opt) {
     fDisk[i].fDr           = 1.e6;
     fDisk[i].fSInt         = 1.e6;
     fDisk[i].fCluster      = NULL;
-    fDisk[i].fExtrk        = NULL;
+    // fDisk[i].fExtrk        = NULL;
   }
 
   fVMinS        = NULL;
@@ -1991,7 +1991,7 @@ void TStnTrack::Clear(Option_t* Opt) {
   fTrkCaloHit.fDr           = 1.e6;
   fTrkCaloHit.fSInt         = 1.e6;
   fTrkCaloHit.fCluster      = NULL;
-  fTrkCaloHit.fExtrk        = NULL;
+  // fTrkCaloHit.fExtrk        = NULL;
 
 					// by definition, LogLH < 0
   fEleLogLHCal  =  1.;

--- a/obj/TStnTriggerTable.cc
+++ b/obj/TStnTriggerTable.cc
@@ -61,7 +61,7 @@ void TStnTriggerTable::GetListOfTriggers(const char* Pattern,
     if (t) {
       trigger_name = t->Name();
       trigger_name.ToUpper();
-      if (strstr(trigger_name,pat) != 0) {
+      if (pat == "" || strstr(trigger_name,pat) != 0) {
 	List->Add((TObject*)t);
       }
     }

--- a/obj/obj/TStnCluster.hh
+++ b/obj/obj/TStnCluster.hh
@@ -38,7 +38,9 @@ class TStnCluster : public TObject {
     kNFreeFloatsV2 =  3, // V2
 
     kNFreeInts     =  8,		// V3
-    kNFreeFloats   =  2			// V3
+    kNFreeFloats   =  1,		// V3
+
+    kNFreeFloats2  = 10 // more space for expansion added in V3
   };
 
 public:
@@ -81,7 +83,11 @@ public:
   float                     fNx   ;    // cluster direction
   float                     fNy   ;
   float                     fMCSimEDep; // MC main sim energy deposit, added in V3
+  float                     fMCEDep; // MC energy deposited, added in V3
   float                     fFloat[kNFreeFloats];
+
+  float                     fMCTime; // MC time, weighted by sim energy dep, added in V3
+  float                     fFloat2[kNFreeFloats2]; // Extra expansion room added in V3
 //-----------------------------------------------------------------------------
 // transients
 //-----------------------------------------------------------------------------

--- a/obj/obj/TStnCluster.hh
+++ b/obj/obj/TStnCluster.hh
@@ -11,7 +11,7 @@
 #define murat_inc_TStnCluster_hh
 
 // storable objects (data products)
-// 
+//
 
 // C++ includes.
 #include <iostream>
@@ -48,11 +48,11 @@ public:
 // integers
 //-----------------------------------------------------------------------------
   int                       fNumber;          // index in the list of reconstructed clusters
-  int                       fDiskID;	      // 
+  int                       fDiskID;	      //
   int                       fNCrystals;       //
   int                       fNCr1     ;       // N crystals above 1 MeV
   int                       fTrackNumber;     // closest track in TStnTrackBlock
-  int                       fIx1;	      // [row, column] or [x1,x2] for a disk
+  int                       fIx1;	      // [row, column] or [x1,x2] for a disk -- Not used
   int                       fIx2;
   int                       fMCSimID;         // Sim particle ID with the highest energy deposit, added in V3
   int                       fMCSimPDG;        // Sim particle PDG with the highest energy deposit, added in V3
@@ -64,12 +64,12 @@ public:
   float                     fY;
   float                     fZ;
   float                     fYMean;
-  float                     fZMean;
-  float                     fSigY;      // cluster width in Y 
-  float                     fSigZ;	// cluster width in Z/X (fSigZ is reused)
+  float                     fZMean;     // Currently actually X mean
+  float                     fSigY;      // cluster width in Y
+  float                     fSigZ;	// cluster width in Z/X (fSigZ is reused as sig X)
   float                     fSigR;      // don't know what it is
   float                     fEnergy   ;
-  float                     fTime     ; 
+  float                     fTime     ;
   float                     fFrE1     ; // e1/etotal
   float                     fFrE2     ; // (e1+e2)/etotal
   float                     fSigE1    ;
@@ -77,16 +77,25 @@ public:
 //-----------------------------------------------------------------------------
 // 7 words added in version 2
 //-----------------------------------------------------------------------------
-  float                     fSigXX;    // sums over crystals
+  float                     fSigXX;      // sums over crystals
   float                     fSigXY;
   float                     fSigYY;
-  float                     fNx   ;    // cluster direction
-  float                     fNy   ;
-  float                     fMCSimEDep; // MC main sim energy deposit, added in V3
-  float                     fMCEDep; // MC energy deposited, added in V3
+  float                     fNx   ;      // cluster direction, cos(phi)
+  float                     fNy   ;      // sin(phi)
+//-----------------------------------------------------------------------------
+// 9 words + expansion space added in version 3
+//-----------------------------------------------------------------------------
+  float                     fTimeRMS;    // RMS of hit times within the cluster
+  float                     fMaxR ;      // max crystal distance from most energetic crystal
   float                     fFloat[kNFreeFloats];
 
-  float                     fMCTime; // MC time, weighted by sim energy dep, added in V3
+  float                     fE9;         // Energy of main crystal + neighbors
+  float                     fE25;        // Energy of main crystal + neighbors and their neighbors
+  float                     fOutRingE;   // Energy of cluster crystals with R > 600 mm
+  float                     fMCSimEDep;  // MC main sim energy deposit, added in V3
+  float                     fMCSimMomIn; // MC main sim momentum in, added in V3
+  float                     fMCEDep;     // MC energy deposited, added in V3
+  float                     fMCTime;     // MC time, weighted by sim energy dep, added in V3
   float                     fFloat2[kNFreeFloats2]; // Extra expansion room added in V3
 //-----------------------------------------------------------------------------
 // transients
@@ -101,32 +110,43 @@ public:
 //-----------------------------------------------------------------------------
 // accessors
 //-----------------------------------------------------------------------------
-  int     DiskID     () { return fDiskID  ; }
-  int     Ix1        () { return fIx1; }
-  int     Ix2        () { return fIx2; }
-  int     NCrystals  () { return fNCrystals; }
-  int     Number     () { return fNumber; }
-  int     TrackNumber() { return fTrackNumber; }
+  int     DiskID      () const { return fDiskID  ; }
+  int     Ix1         () const { return fIx1; }
+  int     Ix2         () const { return fIx2; }
+  int     NCrystals   () const { return fNCrystals; }
+  int     Number      () const { return fNumber; }
+  int     TrackNumber () const { return fTrackNumber; }
 
-  float   Energy     () { return fEnergy; }
-  float   Time       () { return fTime  ; }
+  float   Energy      () const { return fEnergy; }
+  float   Time        () const { return fTime  ; }
 
-  float   Nx         () { return fNx;    }
-  float   Ny         () { return fNy;    }
+  float   Nx          () const { return fNx;    }
+  float   Ny          () const { return fNy;    }
 
-  float   SeedFr     () { return fFrE1;  }
+  float   SeedFr      () const { return fFrE1;  }
+  float   SeedFr2     () const { return fFrE2;  }
 
-  float   SigX       () { return fSigZ;  }
-  float   SigY       () { return fSigY;  }
-  float   SigZ       () { return fSigZ;  }
+  float   SigX        () const { return fSigZ;  }
+  float   SigY        () const { return fSigY;  }
+  float   SigZ        () const { return fSigZ;  }
 
-  float   SigXX      () { return fSigXX; }
-  float   SigXY      () { return fSigXY; }
-  float   SigYY      () { return fSigYY; }
+  float   SigXX       () const { return fSigXX; }
+  float   SigXY       () const { return fSigXY; }
+  float   SigYY       () const { return fSigYY; }
 
+  float   E9          () const { return fE9;    }
+  float   E25         () const { return fE25;   }
+  float   OutRingE    () const { return fOutRingE;}
+
+  // evaluated values
+  float   E1          () const { return SeedFr() * Energy(); } // energy of main hit
+  float   E2          () const { return SeedFr2() * Energy(); } // energy of main two hits
+  float   RingE       () const { return E9() - E1(); } // energy around the main hit
+
+  // linked track
   TStnTrack* ClosestTrack() { return fClosestTrack; }
 
-  void    SetNumber(int I) { fNumber = I; } // 
+  void    SetNumber(int I) { fNumber = I; } //
 
 //-----------------------------------------------------------------------------
 // overloaded methods of TObject

--- a/obj/obj/TStnCluster.hh
+++ b/obj/obj/TStnCluster.hh
@@ -34,9 +34,11 @@ class TStnCluster : public TObject {
   enum {
     kNFreeIntsV1   = 10,		// V1
     kNFreeFloatsV1 = 10,		// V1
+    kNFreeIntsV2   = 10, // V2
+    kNFreeFloatsV2 =  3, // V2
 
-    kNFreeInts     = 10,		// V2
-    kNFreeFloats   =  3			// V2
+    kNFreeInts     =  8,		// V3
+    kNFreeFloats   =  2			// V3
   };
 
 public:
@@ -50,6 +52,8 @@ public:
   int                       fTrackNumber;     // closest track in TStnTrackBlock
   int                       fIx1;	      // [row, column] or [x1,x2] for a disk
   int                       fIx2;
+  int                       fMCSimID;         // Sim particle ID with the highest energy deposit, added in V3
+  int                       fMCSimPDG;        // Sim particle PDG with the highest energy deposit, added in V3
   int                       fInt[kNFreeInts];
 //-----------------------------------------------------------------------------
 // floats
@@ -76,6 +80,7 @@ public:
   float                     fSigYY;
   float                     fNx   ;    // cluster direction
   float                     fNy   ;
+  float                     fMCSimEDep; // MC main sim energy deposit, added in V3
   float                     fFloat[kNFreeFloats];
 //-----------------------------------------------------------------------------
 // transients
@@ -127,7 +132,7 @@ public:
 //-----------------------------------------------------------------------------
   void ReadV1(TBuffer& R__b);
 
-  ClassDef(TStnCluster,2)
+  ClassDef(TStnCluster,3)
 };
 
 #endif

--- a/obj/obj/TStnCluster.hh
+++ b/obj/obj/TStnCluster.hh
@@ -134,14 +134,18 @@ public:
   float   SigXY       () const { return fSigXY; }
   float   SigYY       () const { return fSigYY; }
 
+  float   TimeRMS     () const { return fTimeRMS;}
+  float   MaxDeltaR   () const { return fMaxR;  }
   float   E9          () const { return fE9;    }
   float   E25         () const { return fE25;   }
   float   OutRingE    () const { return fOutRingE;}
 
   // evaluated values
   float   E1          () const { return SeedFr() * Energy(); } // energy of main hit
-  float   E2          () const { return SeedFr2() * Energy(); } // energy of main two hits
+  float   E2          () const { return SeedFr2() * Energy() - E1(); } // energy of the second biggest hit
+  float   E12         () const { return SeedFr2() * Energy(); } // energy of main two hits
   float   RingE       () const { return E9() - E1(); } // energy around the main hit
+  float   R           () const { return std::sqrt(fX*fX + fY*fY); }
 
   // linked track
   TStnTrack* ClosestTrack() { return fClosestTrack; }

--- a/obj/obj/TStnHeaderBlock.hh
+++ b/obj/obj/TStnHeaderBlock.hh
@@ -70,6 +70,7 @@ public:
   int    NTracks      () const { return fNTracks;       }
   int    NStrawHits   () const { return fNStrawHits;    }
   int    NComboHits   () const { return fNComboHits;    }
+  int    NCaloHits    () const { return fNCaloHits;     }
 
   float InstLum       () const { return fInstLum;       }
   float MeanLum       () const { return fMeanLum;       }

--- a/obj/obj/TStnTrack.hh
+++ b/obj/obj/TStnTrack.hh
@@ -30,7 +30,7 @@ class TStnCluster;
 namespace mu2e {
   class KalSeed ;
   class CaloCluster;
-  class TrkToCaloExtrapol;
+  // class TrkToCaloExtrapol;
 }
 
 // namespace murat {
@@ -122,7 +122,7 @@ public:
     float        fDr;                   // ** added in V10: DR(cluster-track), signed
     float        fSInt;                 // ** added in V10: interaction length, calculated
     const mu2e::CaloCluster*       fCluster;
-    const mu2e::TrkToCaloExtrapol* fExtrk;
+    // const mu2e::TrkToCaloExtrapol* fExtrk;
   };
     
   TLorentzVector            fMomentum;        // this assumes DEM fit hypothesis
@@ -212,7 +212,7 @@ public:
 //-----------------------------------------------------------------------------
 //  transient data members, all persistent ones should go above
 //-----------------------------------------------------------------------------
-  const mu2e::TrkToCaloExtrapol* fExtrk;              //!
+  // const mu2e::TrkToCaloExtrapol* fExtrk;              //!
   const mu2e::CaloCluster*       fClosestCaloCluster; //!
 
   InterData_t*                   fVMinS;	      //! intersection with min S

--- a/print/SConscript
+++ b/print/SConscript
@@ -44,7 +44,6 @@ def local_build():
                         'mu2e_RecoDataProducts',
                         'mu2e_DataProducts',
                         'mu2e_CaloMC',
-                        'mu2e_BTrkData',
                                                 
                         babarlibs,
                         

--- a/print/TAnaDump.cc
+++ b/print/TAnaDump.cc
@@ -6,6 +6,7 @@
 
 #include "TROOT.h"
 #include "TVector2.h"
+#include "CLHEP/Vector/ThreeVector.h"
 
 #include "art/Framework/Principal/Handle.h"
 #include "art/Framework/Principal/Run.h"
@@ -46,13 +47,13 @@
 #include "Offline/MCDataProducts/inc/PhysicalVolumeInfo.hh"
 #include "Offline/MCDataProducts/inc/PhysicalVolumeInfoMultiCollection.hh"
 
-#include "Offline/BTrkData/inc/TrkCaloHit.hh"
-#include "Offline/BTrkData/inc/TrkStrawHit.hh"
-#include "Offline/RecoDataProducts/inc/KalRepPtrCollection.hh"
 
-#include "Offline/RecoDataProducts/inc/TrkToCaloExtrapol.hh"
-#include "Offline/RecoDataProducts/inc/TrkCaloIntersect.hh"
-#include "Offline/RecoDataProducts/inc/TrackClusterMatch.hh"
+
+// #include "Offline/RecoDataProducts/inc/KalRepPtrCollection.hh"
+
+// #include "Offline/RecoDataProducts/inc/TrkToCaloExtrapol.hh"
+// #include "Offline/RecoDataProducts/inc/TrkCaloIntersect.hh"
+// #include "Offline/RecoDataProducts/inc/TrackClusterMatch.hh"
 #include "Offline/TrkDiag/inc/TrkMCTools.hh"
 
 #include "Offline/Mu2eUtilities/inc/LsqSums4.hh"
@@ -62,6 +63,7 @@
 #include "Offline/TrkDiag/inc/TrkMCTools.hh"
 
 // BTRK (BaBar) includes
+#include "BTrk/BbrGeom/HepPoint.h"
 #include "BTrk/BbrGeom/TrkLineTraj.hh"
 #include "BTrk/TrkBase/TrkPoca.hh"
 #include "BTrk/KalmanTrack/KalHit.hh"
@@ -69,10 +71,12 @@
 #include "BTrk/TrkBase/HelixParams.hh"
 #include "BTrk/ProbTools/ChisqConsistency.hh"
 
-#include "Offline/TrkReco/inc/TrkPrintUtils.hh"
+// #include "Offline/TrkReco/inc/TrkPrintUtils.hh"
 
+#include "CLHEP/Geometry/Point3D.h"
 
 using namespace std;
+// typedef HepGeom::Point3D<double> HepPoint;
 
 ClassImp(TAnaDump)
 
@@ -139,7 +143,7 @@ TAnaDump::TAnaDump(const fhicl::ParameterSet* PSet) {
   fFlagBgrHitsModuleLabel = "FlagBkgHits";
   fSdmcCollTag            = "compressDigiMCs";
 
-  _printUtils = new mu2e::TrkPrintUtils(PSet->get<fhicl::ParameterSet>("printUtils",fhicl::ParameterSet()));
+  // _printUtils = new mu2e::TrkPrintUtils(PSet->get<fhicl::ParameterSet>("printUtils",fhicl::ParameterSet()));
 }
 
 // //-----------------------------------------------------------------------------
@@ -165,7 +169,7 @@ TAnaDump* TAnaDump::Instance(const fhicl::ParameterSet* PSet) {
 TAnaDump::~TAnaDump() {
   fListOfObjects->Delete();
   delete fListOfObjects;
-  delete _printUtils;
+  // delete _printUtils;
 }
 
 //------------------------------------------------------------------------------
@@ -209,7 +213,7 @@ void TAnaDump::printCaloCluster(const mu2e::CaloCluster* Cl,
 
   art::ServiceHandle<mu2e::GeometryService> geom;
   mu2e::GeomHandle  <mu2e::Calorimeter>     cal;
-  Hep3Vector        gpos, tpos;
+  CLHEP::Hep3Vector        gpos, tpos;
 
   if ((opt == "") || (opt.Index("banner") >= 0)) {
     printf("-----------------------------------------------------------------------------------------------");
@@ -1054,136 +1058,136 @@ void TAnaDump::printEventHeader() {
 	 fEvent->event());
 }
 
-//-----------------------------------------------------------------------------
-void TAnaDump::printTrkCaloHit(const KalRep* Krep, mu2e::TrkCaloHit* CaloHit){
-  double    len  = CaloHit->fltLen();
-  HepPoint  plen = Krep->position(len);
+// //-----------------------------------------------------------------------------
+// void TAnaDump::printTrkCaloHit(const KalRep* Krep, mu2e::TrkCaloHit* CaloHit){
+//   double    len  = CaloHit->fltLen();
+//   HepPoint  plen = Krep->position(len);
   
-  printf("%3i %5i 0x%08x %1i %9.3f %8.3f %8.3f %9.3f %8.3f %7.3f",
-	 -1,//++i,
-	 0, //straw->index().asInt(), 
-	 CaloHit->hitFlag(),
-	 //	     hit->isUsable(),
-	 CaloHit->isActive(),
-	 len,
-	 //	     hit->hitRms(),
-	 plen.x(),plen.y(),plen.z(),
-	 CaloHit->time(), -1.//sh->dt()
-	 );
+//   printf("%3i %5i 0x%08x %1i %9.3f %8.3f %8.3f %9.3f %8.3f %7.3f",
+// 	 -1,//++i,
+// 	 0, //straw->index().asInt(), 
+// 	 CaloHit->hitFlag(),
+// 	 //	     hit->isUsable(),
+// 	 CaloHit->isActive(),
+// 	 len,
+// 	 //	     hit->hitRms(),
+// 	 plen.x(),plen.y(),plen.z(),
+// 	 CaloHit->time(), -1.//sh->dt()
+// 	 );
 
-  printf(" %2i %2i %2i %2i",
-	 -1,//straw->id().getPlane(),
-	 -1,//straw->id().getPanel(),
-	 -1,//straw->id().getLayer(),
-	 -1//straw->id().getStraw()
-	 );
+//   printf(" %2i %2i %2i %2i",
+// 	 -1,//straw->id().getPlane(),
+// 	 -1,//straw->id().getPanel(),
+// 	 -1,//straw->id().getLayer(),
+// 	 -1//straw->id().getStraw()
+// 	 );
 
-  printf(" %8.3f",CaloHit->hitT0().t0());
+//   printf(" %8.3f",CaloHit->hitT0().t0());
   
-  double res, sigres;
-  CaloHit->resid(res, sigres, true);
+//   double res, sigres;
+//   CaloHit->resid(res, sigres, true);
 
-  CLHEP::Hep3Vector  pos;
-  CaloHit->hitPosition(pos);
+//   CLHEP::Hep3Vector  pos;
+//   CaloHit->hitPosition(pos);
 
-  printf("%8.3f %8.3f %9.3f %7.3f %7.3f",
-	 pos.x(),
-	 pos.y(),
-	 pos.z(),
-	 res,
-	 sigres
-	 );
+//   printf("%8.3f %8.3f %9.3f %7.3f %7.3f",
+// 	 pos.x(),
+// 	 pos.y(),
+// 	 pos.z(),
+// 	 res,
+// 	 sigres
+// 	 );
       
-  printf("   %6.3f", -1.);//CaloHit->driftRadius());
+//   printf("   %6.3f", -1.);//CaloHit->driftRadius());
   
 	  
 
-  printf("  %7.3f",-1.);
+//   printf("  %7.3f",-1.);
 
-  double exterr = CaloHit->temperature();//*CaloHit->driftVelocity();
+//   double exterr = CaloHit->temperature();//*CaloHit->driftVelocity();
 
-  printf(" %6.3f %6.3f %6.3f %6.3f %6.3f",		 
-	 -1.,//CaloHit->totalErr(),
-	 CaloHit->hitErr(),
-	 CaloHit->hitT0().t0Err(),
-	 -1.,//,CaloHit->penaltyErr(),
-	 exterr
-	 );
-  //-----------------------------------------------------------------------------
-  // test: calculated residual in fTmp[0]
-  //-----------------------------------------------------------------------------
-  //       Test_000(Krep,hit);
-  //       printf(" %7.3f",fTmp[0]);
+//   printf(" %6.3f %6.3f %6.3f %6.3f %6.3f",		 
+// 	 -1.,//CaloHit->totalErr(),
+// 	 CaloHit->hitErr(),
+// 	 CaloHit->hitT0().t0Err(),
+// 	 -1.,//,CaloHit->penaltyErr(),
+// 	 exterr
+// 	 );
+//   //-----------------------------------------------------------------------------
+//   // test: calculated residual in fTmp[0]
+//   //-----------------------------------------------------------------------------
+//   //       Test_000(Krep,hit);
+//   //       printf(" %7.3f",fTmp[0]);
 
-  printf("\n");
+//   printf("\n");
 
-}
+// }
 
-//-----------------------------------------------------------------------------
-// ""       : banner+track parameters (default)
-// "banner" : banner only
-// "data"   : track parameters only
-// "hits"   : hits
-//-----------------------------------------------------------------------------
-void TAnaDump::printKalRep(const KalRep* Krep, const char* Opt, const char* Prefix) {
+// //-----------------------------------------------------------------------------
+// // ""       : banner+track parameters (default)
+// // "banner" : banner only
+// // "data"   : track parameters only
+// // "hits"   : hits
+// //-----------------------------------------------------------------------------
+// void TAnaDump::printKalRep(const KalRep* Krep, const char* Opt, const char* Prefix) {
 
-  //  TString opt = Opt;
+//   //  TString opt = Opt;
 
-  _printUtils->printTrack(fEvent,Krep,Opt,Prefix);
-}
+//   _printUtils->printTrack(fEvent,Krep,Opt,Prefix);
+// }
 
-//-----------------------------------------------------------------------------
-void TAnaDump::printKalRepCollection(const char* KalRepCollTag     , 
-				     int         hitOpt            ,
-				     const char* StrawDigiMCCollTag) {
+// //-----------------------------------------------------------------------------
+// void TAnaDump::printKalRepCollection(const char* KalRepCollTag     , 
+// 				     int         hitOpt            ,
+// 				     const char* StrawDigiMCCollTag) {
 
-  art::InputTag                          krepCollTag(KalRepCollTag);
-  art::Handle<mu2e::KalRepPtrCollection> krepsHandle; 
-//-----------------------------------------------------------------------------
-// make sure collection exists
-//-----------------------------------------------------------------------------
-  fEvent->getByLabel(krepCollTag,krepsHandle);
-  if (! krepsHandle.isValid()) {
-    printf("TAnaDump::printKalRepCollection: no KalRepPtrCollection tag=%s, BAIL OUT\n", KalRepCollTag);
-    printf(" available ones are:\n");
-    print_kalrep_colls();
-    return;
-  }
+//   art::InputTag                          krepCollTag(KalRepCollTag);
+//   art::Handle<mu2e::KalRepPtrCollection> krepsHandle; 
+// //-----------------------------------------------------------------------------
+// // make sure collection exists
+// //-----------------------------------------------------------------------------
+//   fEvent->getByLabel(krepCollTag,krepsHandle);
+//   if (! krepsHandle.isValid()) {
+//     printf("TAnaDump::printKalRepCollection: no KalRepPtrCollection tag=%s, BAIL OUT\n", KalRepCollTag);
+//     printf(" available ones are:\n");
+//     print_kalrep_colls();
+//     return;
+//   }
 
-  art::InputTag sdmc_tag = StrawDigiMCCollTag;
-  if (sdmc_tag == "") sdmc_tag = fSdmcCollTag;
+//   art::InputTag sdmc_tag = StrawDigiMCCollTag;
+//   if (sdmc_tag == "") sdmc_tag = fSdmcCollTag;
 
-  art::Handle<mu2e::StrawDigiMCCollection> sdmccH;
-  fEvent->getByLabel<mu2e::StrawDigiMCCollection>(sdmc_tag,sdmccH);
+//   art::Handle<mu2e::StrawDigiMCCollection> sdmccH;
+//   fEvent->getByLabel<mu2e::StrawDigiMCCollection>(sdmc_tag,sdmccH);
 
-  if (sdmccH.isValid()) _mcdigis = sdmccH.product();
-  else                  _mcdigis = nullptr;
+//   if (sdmccH.isValid()) _mcdigis = sdmccH.product();
+//   else                  _mcdigis = nullptr;
 
-  if (_mcdigis == nullptr) {
-    printf(">>> ERROR in TAnaDump::printKalRepCollection: failed to locate StepPointMCCollection:: by %s\n",
-           sdmc_tag.encode().data());
-  }
+//   if (_mcdigis == nullptr) {
+//     printf(">>> ERROR in TAnaDump::printKalRepCollection: failed to locate StepPointMCCollection:: by %s\n",
+//            sdmc_tag.encode().data());
+//   }
 
-  int ntrk = krepsHandle->size();
+//   int ntrk = krepsHandle->size();
 
-  const KalRep *trk;
+//   const KalRep *trk;
 
-  int banner_printed = 0;
-  for (int i=0; i<ntrk; i++) {
-    art::Ptr<KalRep> kptr = krepsHandle->at(i);
-    //    fEvent->get(kptr.id(), krepsHandle);
-    fhicl::ParameterSet const& pset = krepsHandle.provenance()->parameterSet();
-    string module_type = pset.get<string>("module_type");
+//   int banner_printed = 0;
+//   for (int i=0; i<ntrk; i++) {
+//     art::Ptr<KalRep> kptr = krepsHandle->at(i);
+//     //    fEvent->get(kptr.id(), krepsHandle);
+//     fhicl::ParameterSet const& pset = krepsHandle.provenance()->parameterSet();
+//     string module_type = pset.get<string>("module_type");
  
-    trk = kptr.get();
-    if (banner_printed == 0) {
-      printKalRep(trk,"banner",module_type.data());
-      banner_printed = 1;
-    }
-    printKalRep(trk,"data",module_type.data());
-    if (hitOpt > 0) printKalRep(trk,"hits");
-  }
-}
+//     trk = kptr.get();
+//     if (banner_printed == 0) {
+//       printKalRep(trk,"banner",module_type.data());
+//       banner_printed = 1;
+//     }
+//     printKalRep(trk,"data",module_type.data());
+//     if (hitOpt > 0) printKalRep(trk,"hits");
+//   }
+// }
 
 
 //-----------------------------------------------------------------------------
@@ -1478,77 +1482,77 @@ void TAnaDump::printCaloRecoDigiCollection(const char* ModuleLabel,
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TAnaDump::printTrkToCaloExtrapol(const mu2e::TrkToCaloExtrapol* trkToCalo,
-				      const char* Opt) {
- TString opt = Opt;
+// void TAnaDump::printTrkToCaloExtrapol(const mu2e::TrkToCaloExtrapol* trkToCalo,
+// 				      const char* Opt) {
+//  TString opt = Opt;
 
-  if ((opt == "") || (opt == "banner")) {
-    printf("-------------------------------------------------------------------------------------------------------\n");
-    printf("sectionId      Time     ExtPath     Ds       FitCon      t0          X           Y        Z          Mom  \n");
-    printf("-------------------------------------------------------------------------------------------------------\n");
-  }
+//   if ((opt == "") || (opt == "banner")) {
+//     printf("-------------------------------------------------------------------------------------------------------\n");
+//     printf("sectionId      Time     ExtPath     Ds       FitCon      t0          X           Y        Z          Mom  \n");
+//     printf("-------------------------------------------------------------------------------------------------------\n");
+//   }
   
-  if ((opt == "") || (opt.Index("data") >= 0)) {
+//   if ((opt == "") || (opt.Index("data") >= 0)) {
 
-    double ds = trkToCalo->pathLengthExit()-trkToCalo->pathLengthEntrance();
+//     double ds = trkToCalo->pathLengthExit()-trkToCalo->pathLengthEntrance();
   
-    printf("%6i %10.3f %10.3f %8.3f %10.3f %10.3f %10.3f %10.3f %10.3f %10.3f \n",
-	   trkToCalo->diskId(),
-	   trkToCalo->time(),
-	   trkToCalo->pathLengthEntrance(),
-	   ds,
-	   trkToCalo->fitConsistency(),
-	   trkToCalo->t0(),
-	   trkToCalo->entrancePosition().x(),
-	   trkToCalo->entrancePosition().y(),
-	   trkToCalo->entrancePosition().z(),
-	   trkToCalo->momentum().mag() );
-  }
+//     printf("%6i %10.3f %10.3f %8.3f %10.3f %10.3f %10.3f %10.3f %10.3f %10.3f \n",
+// 	   trkToCalo->diskId(),
+// 	   trkToCalo->time(),
+// 	   trkToCalo->pathLengthEntrance(),
+// 	   ds,
+// 	   trkToCalo->fitConsistency(),
+// 	   trkToCalo->t0(),
+// 	   trkToCalo->entrancePosition().x(),
+// 	   trkToCalo->entrancePosition().y(),
+// 	   trkToCalo->entrancePosition().z(),
+// 	   trkToCalo->momentum().mag() );
+//   }
   
-}
+// }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TAnaDump::printTrkToCaloExtrapolCollection(const char* ModuleLabel, 
-						const char* ProductName,
-						const char* ProcessName) {
+// void TAnaDump::printTrkToCaloExtrapolCollection(const char* ModuleLabel, 
+// 						const char* ProductName,
+// 						const char* ProcessName) {
 
-  printf(">>>> ModuleLabel = %s\n",ModuleLabel);
+//   printf(">>>> ModuleLabel = %s\n",ModuleLabel);
 
-  //data about hits in the calorimeter crystals
+//   //data about hits in the calorimeter crystals
 
-  art::Handle<mu2e::TrkToCaloExtrapolCollection> trkToCaloHandle;
-  const mu2e::TrkToCaloExtrapolCollection* trkToCalo;
+//   art::Handle<mu2e::TrkToCaloExtrapolCollection> trkToCaloHandle;
+//   const mu2e::TrkToCaloExtrapolCollection* trkToCalo;
 
-  if (ProductName[0] != 0) {
-    art::Selector  selector(art::ProductInstanceNameSelector(ProductName) &&
-			    art::ProcessNameSelector(ProcessName)         && 
-			    art::ModuleLabelSelector(ModuleLabel)            );
-    fEvent->get(selector, trkToCaloHandle);
-  }
-  else {
-    art::Selector  selector(art::ProcessNameSelector(ProcessName)         && 
-			    art::ModuleLabelSelector(ModuleLabel)            );
-    fEvent->get(selector, trkToCaloHandle);
-  }
+//   if (ProductName[0] != 0) {
+//     art::Selector  selector(art::ProductInstanceNameSelector(ProductName) &&
+// 			    art::ProcessNameSelector(ProcessName)         && 
+// 			    art::ModuleLabelSelector(ModuleLabel)            );
+//     fEvent->get(selector, trkToCaloHandle);
+//   }
+//   else {
+//     art::Selector  selector(art::ProcessNameSelector(ProcessName)         && 
+// 			    art::ModuleLabelSelector(ModuleLabel)            );
+//     fEvent->get(selector, trkToCaloHandle);
+//   }
 
-  trkToCalo = trkToCaloHandle.operator ->();
+//   trkToCalo = trkToCaloHandle.operator ->();
 
-  int nhits = trkToCalo->size();
+//   int nhits = trkToCalo->size();
 
-  const mu2e::TrkToCaloExtrapol* hit;
+//   const mu2e::TrkToCaloExtrapol* hit;
   
-  int banner_printed = 0;
-  for (int i=0; i<nhits; i++) {
-    hit = &trkToCalo->at(i);
-    if (banner_printed == 0) {
-      printTrkToCaloExtrapol(hit, "banner");
-      banner_printed = 1;
-    }
-    printTrkToCaloExtrapol(hit,"data");
-  }
+//   int banner_printed = 0;
+//   for (int i=0; i<nhits; i++) {
+//     hit = &trkToCalo->at(i);
+//     if (banner_printed == 0) {
+//       printTrkToCaloExtrapol(hit, "banner");
+//       banner_printed = 1;
+//     }
+//     printTrkToCaloExtrapol(hit,"data");
+//   }
   
-}
+// }
 
 
 
@@ -1873,10 +1877,10 @@ void TAnaDump::printStepPointMC(const mu2e::StepPointMC* Step, const char* Detec
     if ((strcmp(Detector,"tracker") == 0) && tracker) {
       const mu2e::Straw* straw = &tracker->getStraw(mu2e::StrawId(Step->volumeId()));
 
-      const Hep3Vector* v1 = &straw->getMidPoint();
+      const CLHEP::Hep3Vector* v1 = &straw->getMidPoint();
       HepPoint p1(v1->x(),v1->y(),v1->z());
 
-      const Hep3Vector* v2 = &Step->position();
+      const CLHEP::Hep3Vector* v2 = &Step->position();
       HepPoint    p2(v2->x(),v2->y(),v2->z());
 
       TrkLineTraj trstraw(p1,straw->getDirection()  ,0.,0.);
@@ -1900,7 +1904,7 @@ void TAnaDump::printStepPointMC(const mu2e::StepPointMC* Step, const char* Detec
     double energy = sqrt(pabs*pabs+mass*mass);
     double ekin  = energy-mass;
         
-    Hep3Vector mom = Step->momentum();
+    CLHEP::Hep3Vector mom = Step->momentum();
     double pt = sqrt(pabs*pabs - mom.z()*mom.z());
 
     art::Handle<mu2e::PhysicalVolumeInfoMultiCollection> volumes;
@@ -2046,196 +2050,196 @@ void TAnaDump::printStepPointMCCollection(const char* ModuleLabel,
  
 // }
 
-//-----------------------------------------------------------------------------
-void TAnaDump::printTrackClusterMatch(const mu2e::TrackClusterMatch* Tcm, const char* Opt) {
+// //-----------------------------------------------------------------------------
+// void TAnaDump::printTrackClusterMatch(const mu2e::TrackClusterMatch* Tcm, const char* Opt) {
 
-  TString opt = Opt;
+//   TString opt = Opt;
   
-  if ((opt == "") || (opt == "banner")) {
-    printf("--------------------------------------------------------------------------------------\n");
-    printf("  Disk         Cluster          Track         chi2     du        dv       dt       E/P\n");
-    printf("--------------------------------------------------------------------------------------\n");
-  }
+//   if ((opt == "") || (opt == "banner")) {
+//     printf("--------------------------------------------------------------------------------------\n");
+//     printf("  Disk         Cluster          Track         chi2     du        dv       dt       E/P\n");
+//     printf("--------------------------------------------------------------------------------------\n");
+//   }
 
-  if ((opt == "") || (opt == "data")) {
+//   if ((opt == "") || (opt == "data")) {
 
-    const mu2e::CaloCluster*      cl  = Tcm->caloCluster();
-    const mu2e::TrkCaloIntersect* tex = Tcm->textrapol  ();
+//     const mu2e::CaloCluster*      cl  = Tcm->caloCluster();
+//     const mu2e::TrkCaloIntersect* tex = Tcm->textrapol  ();
 
-    int disk     = cl->diskID();
-    double chi2  = Tcm->chi2();
+//     int disk     = cl->diskID();
+//     double chi2  = Tcm->chi2();
 
-    printf("%5i %16p  %16p  %8.3f %8.3f %8.3f %8.3f %8.3f\n",
-	   disk,  static_cast<const void*>(cl),  static_cast<const void*>(tex),  chi2,Tcm->du(),Tcm->dv(),Tcm->dt(),Tcm->ep());
-  }
-}
+//     printf("%5i %16p  %16p  %8.3f %8.3f %8.3f %8.3f %8.3f\n",
+// 	   disk,  static_cast<const void*>(cl),  static_cast<const void*>(tex),  chi2,Tcm->du(),Tcm->dv(),Tcm->dt(),Tcm->ep());
+//   }
+// }
 
 
 
-//-----------------------------------------------------------------------------
-void TAnaDump::printTrackClusterMatchCollection(const char* ModuleLabel, 
-						const char* ProductName,
-						const char* ProcessName) {
+// //-----------------------------------------------------------------------------
+// void TAnaDump::printTrackClusterMatchCollection(const char* ModuleLabel, 
+// 						const char* ProductName,
+// 						const char* ProcessName) {
 
-  printf(">>>> ModuleLabel = %s\n",ModuleLabel);
+//   printf(">>>> ModuleLabel = %s\n",ModuleLabel);
 
-  art::Handle<mu2e::TrackClusterMatchCollection> handle;
-  const mu2e::TrackClusterMatchCollection*       coll;
+//   art::Handle<mu2e::TrackClusterMatchCollection> handle;
+//   const mu2e::TrackClusterMatchCollection*       coll;
 
-  art::Selector  selector(art::ProductInstanceNameSelector(ProductName) &&
-			  art::ProcessNameSelector(ProcessName)         && 
-			  art::ModuleLabelSelector(ModuleLabel)            );
+//   art::Selector  selector(art::ProductInstanceNameSelector(ProductName) &&
+// 			  art::ProcessNameSelector(ProcessName)         && 
+// 			  art::ModuleLabelSelector(ModuleLabel)            );
 
-  fEvent->get(selector,handle);
+//   fEvent->get(selector,handle);
 
-  if (handle.isValid()) coll = handle.product();
-  else {
-    printf(">>> ERROR in TAnaDump::printTrackClusterMatchCollection: failed to locate requested collection. Available:");
+//   if (handle.isValid()) coll = handle.product();
+//   else {
+//     printf(">>> ERROR in TAnaDump::printTrackClusterMatchCollection: failed to locate requested collection. Available:");
 
-    // vector<art::Handle<mu2e::TrackClusterMatchCollection>> list_of_handles;
-    auto list_of_handles = fEvent->getMany<mu2e::TrackClusterMatchCollection>();
+//     // vector<art::Handle<mu2e::TrackClusterMatchCollection>> list_of_handles;
+//     auto list_of_handles = fEvent->getMany<mu2e::TrackClusterMatchCollection>();
 
-    for (auto ih=list_of_handles.begin(); ih<list_of_handles.end(); ih++) {
-      printf("%s\n", ih->provenance()->moduleLabel().data());
-    }
+//     for (auto ih=list_of_handles.begin(); ih<list_of_handles.end(); ih++) {
+//       printf("%s\n", ih->provenance()->moduleLabel().data());
+//     }
 
-    printf(". BAIL OUT. \n");
-    return;
-  }
+//     printf(". BAIL OUT. \n");
+//     return;
+//   }
 
-  int nm = coll->size();
+//   int nm = coll->size();
 
-  const mu2e::TrackClusterMatch* obj;
+//   const mu2e::TrackClusterMatch* obj;
 
-  int banner_printed = 0;
+//   int banner_printed = 0;
 
-  for (int i=0; i<nm; i++) {
-    obj = &coll->at(i);
-    if (banner_printed == 0) {
-      printTrackClusterMatch(obj, "banner");
-      banner_printed = 1;
-    }
-    printTrackClusterMatch(obj,"data");
-  }
+//   for (int i=0; i<nm; i++) {
+//     obj = &coll->at(i);
+//     if (banner_printed == 0) {
+//       printTrackClusterMatch(obj, "banner");
+//       banner_printed = 1;
+//     }
+//     printTrackClusterMatch(obj,"data");
+//   }
  
-}
+// }
 
 
 //-----------------------------------------------------------------------------
-void TAnaDump::refitTrack(void* Trk, double NSig) {
-  KalRep* trk = (KalRep*) Trk;
+// void TAnaDump::refitTrack(void* Trk, double NSig) {
+//   KalRep* trk = (KalRep*) Trk;
 
-  const TrkHitVector* hits = &trk->hitVector();
+//   const TrkHitVector* hits = &trk->hitVector();
 
-  for (auto it=hits->begin(); it!=hits->end(); it++) {
+//   for (auto it=hits->begin(); it!=hits->end(); it++) {
 
-    // TrkStrawHit inherits from TrkHitOnTrk
+//     // TrkStrawHit inherits from TrkHitOnTrk
 
-    TrkHit* hit = (TrkHit*) &(*it);
+//     TrkHit* hit = (TrkHit*) &(*it);
 
-    const mu2e::TrkStrawHit* straw_hit = (const mu2e::TrkStrawHit*) (*it);
+//     const mu2e::TrkStrawHit* straw_hit = (const mu2e::TrkStrawHit*) (*it);
 
-    double res = straw_hit->resid();
+//     double res = straw_hit->resid();
 
-    if (fabs(res) > 0.1*NSig) {
-      trk->deactivateHit(hit);
-    }
-  }
-
-  trk->fit();
-
-  printKalRep(trk, "hits");
-}
-
-
-//-----------------------------------------------------------------------------
-// emulate calculation of the unbiased residual
-//-----------------------------------------------------------------------------
-void TAnaDump::Test_000(const KalRep* Krep, mu2e::TrkStrawHit* Hit) {
-
-//  apparently, Hit has (had ?) once to be on the track ?
-
-  // double             s, slen, rdrift, sflt, tflt, doca/*, sig , xdr*/;
-  // const mu2e::Straw *straw;
-  // int                sign /*, shId, layer*/;
-  // HepPoint           spi , tpi , hpos;
- 
-  // CLHEP::Hep3Vector  spos, sdir;
-  // TrkSimpTraj  *ptraj(NULL);
-
-  fTmp[0] = -1;
-  fTmp[1] = -1;
-
-//   KalRep* krep = Krep->clone();
-
-//   straw  = &Hit->straw();
-//   //  layer  = straw->id().getLayer();
-//   rdrift = Hit->driftRadius();
-//   //  shId   = straw->index().asInt();
-  
-//   //  const KalHit* khit = krep->findHotSite(Hit);
-
-//   s      = Hit->fltLen();
-
-//   //  int active = Hit->isActive();
-
-// //   if (active) krep->deactivateHot(Hit);
-
-// //   krep->resetFit();
-// //   krep->fit();
-// // 					// local track trajectory
-// //   ptraj = krep->localTrajectory(s,slen);
-
-//   vector<KalSite*>::const_iterator itt;
-//   int found = 0;
-//   for (auto /* vector<KalSite*>::const_iterator */ it=krep->siteList().begin();
-//        it!= krep->siteList().end(); it++) {
-//     const KalHit* kalhit = (*it)->kalHit();
-//     if (kalhit && (kalhit->hitOnTrack() == Hit)) {
-//       itt   = it;
-//       found = 1;
-//       break;
+//     if (fabs(res) > 0.1*NSig) {
+//       trk->deactivateHit(hit);
 //     }
 //   }
+
+//   trk->fit();
+
+//   printKalRep(trk, "hits");
+// }
+
+
+// //-----------------------------------------------------------------------------
+// // emulate calculation of the unbiased residual
+// //-----------------------------------------------------------------------------
+// void TAnaDump::Test_000(const KalRep* Krep, mu2e::TrkStrawHit* Hit) {
+
+// //  apparently, Hit has (had ?) once to be on the track ?
+
+//   // double             s, slen, rdrift, sflt, tflt, doca/*, sig , xdr*/;
+//   // const mu2e::Straw *straw;
+//   // int                sign /*, shId, layer*/;
+//   // HepPoint           spi , tpi , hpos;
+ 
+//   // CLHEP::Hep3Vector  spos, sdir;
+//   // TrkSimpTraj  *ptraj(NULL);
+
+//   fTmp[0] = -1;
+//   fTmp[1] = -1;
+
+// //   KalRep* krep = Krep->clone();
+
+// //   straw  = &Hit->straw();
+// //   //  layer  = straw->id().getLayer();
+// //   rdrift = Hit->driftRadius();
+// //   //  shId   = straw->index().asInt();
+  
+// //   //  const KalHit* khit = krep->findHotSite(Hit);
+
+// //   s      = Hit->fltLen();
+
+// //   //  int active = Hit->isActive();
+
+// // //   if (active) krep->deactivateHot(Hit);
+
+// // //   krep->resetFit();
+// // //   krep->fit();
+// // // 					// local track trajectory
+// // //   ptraj = krep->localTrajectory(s,slen);
+
+// //   vector<KalSite*>::const_iterator itt;
+// //   int found = 0;
+// //   for (auto /* vector<KalSite*>::const_iterator */ it=krep->siteList().begin();
+// //        it!= krep->siteList().end(); it++) {
+// //     const KalHit* kalhit = (*it)->kalHit();
+// //     if (kalhit && (kalhit->hitOnTrack() == Hit)) {
+// //       itt   = it;
+// //       found = 1;
+// //       break;
+// //     }
+// //   }
       
-//   if (found == 0) {
-//     ptraj = (TrkSimpTraj  *) krep->localTrajectory(s,slen);
-//   }
-//   else {
-//     krep->smoothedTraj(itt,itt,ptraj);
-//   }
+// //   if (found == 0) {
+// //     ptraj = (TrkSimpTraj  *) krep->localTrajectory(s,slen);
+// //   }
+// //   else {
+// //     krep->smoothedTraj(itt,itt,ptraj);
+// //   }
 
-//   spos = straw->getMidPoint();
-//   sdir = straw->getDirection();
-// 					// convert Hep3Vector into HepPoint
+// //   spos = straw->getMidPoint();
+// //   sdir = straw->getDirection();
+// // 					// convert Hep3Vector into HepPoint
 
-//   HepPoint    p1(spos.x(),spos.y(),spos.z());
+// //   HepPoint    p1(spos.x(),spos.y(),spos.z());
 
-// 					// wire as a trajectory
-//   TrkLineTraj st(p1,sdir,0.,0.);
+// // 					// wire as a trajectory
+// //   TrkLineTraj st(p1,sdir,0.,0.);
 
-//   TrkPoca poca = TrkPoca(st,0.,*ptraj,0);
+// //   TrkPoca poca = TrkPoca(st,0.,*ptraj,0);
 
-//   Hep3Vector        sdi , tdi, u;
+// //   Hep3Vector        sdi , tdi, u;
 
-//   sflt = poca.flt1();
-//   tflt = poca.flt2();
+// //   sflt = poca.flt1();
+// //   tflt = poca.flt2();
 
-//   st.getInfo(sflt,spi,sdi);
-//   ptraj->getInfo(tflt,tpi,tdi);
+// //   st.getInfo(sflt,spi,sdi);
+// //   ptraj->getInfo(tflt,tpi,tdi);
       
-//   u    = sdi.cross(tdi).unit();  // direction towards the center
+// //   u    = sdi.cross(tdi).unit();  // direction towards the center
 
-//   sign     = Hit->ambig();
-//   hpos     = spi+u*rdrift*sign;
-// 					// hit residal is positive when its residual vector 
-// 					// points inside
-//   doca     = (tpi-hpos).dot(u);
-//   //  sig      = sqrt(rdrift*rdrift +0.1*0.1); // 2.5; // 1.; // hit[ih]->hitRms();
-//   //  xdr      = doca/sig;
+// //   sign     = Hit->ambig();
+// //   hpos     = spi+u*rdrift*sign;
+// // 					// hit residal is positive when its residual vector 
+// // 					// points inside
+// //   doca     = (tpi-hpos).dot(u);
+// //   //  sig      = sqrt(rdrift*rdrift +0.1*0.1); // 2.5; // 1.; // hit[ih]->hitRms();
+// //   //  xdr      = doca/sig;
 
-//   fTmp[0]  = doca;
+// //   fTmp[0]  = doca;
 
-  //  if (active) krep->activateHot(Hit);
+//   //  if (active) krep->activateHot(Hit);
 
-}
+// }

--- a/print/print/TAnaDump.hh
+++ b/print/print/TAnaDump.hh
@@ -53,7 +53,7 @@ namespace mu2e {
   class CrvRecoPulse;
   class CrvCoincidence;
   class CrvCoincidenceCluster;
-  class TrkToCaloExtrapol;
+  // class TrkToCaloExtrapol;
   class StepPointMC;
   class StrawGasStep;
   class GenParticle;
@@ -64,9 +64,7 @@ namespace mu2e {
   class CosmicTrackSeed;
   class HelixSeed;
   class TrackClusterMatch;
-  class TrkCaloHit;
-  class TrkStrawHit;
-  class TrkPrintUtils;
+  // class TrkPrintUtils;
 }
 
 class KalRep;
@@ -91,7 +89,7 @@ public:
   const mu2e::StrawDigiMCCollection* _mcdigis;
   double                             fTmp[100];  // for testing
 
-  mu2e::TrkPrintUtils*               _printUtils;
+  // mu2e::TrkPrintUtils*               _printUtils;
 
 private:
 
@@ -265,11 +263,11 @@ public:
 				const char* StrawHitCollTag    = "makeSH"         ,
 				const char* StrawDigiMCCollTag = "compressDigiMCs");
 
-  void printKalRep(const KalRep* Krep, const char* Opt = "", const char* Prefix = "");
+  // void printKalRep(const KalRep* Krep, const char* Opt = "", const char* Prefix = "");
 
-  void printKalRepCollection(const char* KalRepCollTag               , 
-			     int         hitOpt             = 0      , 
-			     const char* StrawDigiMCCollTag = nullptr); 
+  // void printKalRepCollection(const char* KalRepCollTag               , 
+  //       		     int         hitOpt             = 0      , 
+  //       		     const char* StrawDigiMCCollTag = nullptr); 
 //-----------------------------------------------------------------------------
 // MC truth: gen and sim particles
 //-----------------------------------------------------------------------------
@@ -325,28 +323,28 @@ public:
 //-----------------------------------------------------------------------------
 // calorimeter cluster added to the track fit
 //-----------------------------------------------------------------------------
-  void printTrkCaloHit(const KalRep* Krep, mu2e::TrkCaloHit* CaloHit);
+  // void printTrkCaloHit(const KalRep* Krep, mu2e::TrkCaloHit* CaloHit);
 //-----------------------------------------------------------------------------
 // extrapolation and track-to-calorimeter matching
 //-----------------------------------------------------------------------------
-  void printTrkToCaloExtrapol           (const mu2e::TrkToCaloExtrapol*extrk,
-					 const char* Opt = "");
+  // void printTrkToCaloExtrapol           (const mu2e::TrkToCaloExtrapol*extrk,
+  //       				 const char* Opt = "");
 
-  void printTrkToCaloExtrapolCollection (const char* ModuleLabel, 
-					 const char* ProductName = "", 
-					 const char* ProcessName = "");
+  // void printTrkToCaloExtrapolCollection (const char* ModuleLabel, 
+  //       				 const char* ProductName = "", 
+  //       				 const char* ProcessName = "");
 
-  void printTrackClusterMatch           (const mu2e::TrackClusterMatch* TcMatch, const char* Option);
+  // void printTrackClusterMatch           (const mu2e::TrackClusterMatch* TcMatch, const char* Option);
 
 
-  void printTrackClusterMatchCollection(const char* ModuleLabel     , 
-					const char* ProductName = "", 
-					const char* ProcessName = "");
+  // void printTrackClusterMatchCollection(const char* ModuleLabel     , 
+  //       				const char* ProductName = "", 
+  //       				const char* ProcessName = "");
   
-					// refit track dropping hits away > NSig sigma (0.1)
-  void  refitTrack(void* Trk, double NSig);
+  //       				// refit track dropping hits away > NSig sigma (0.1)
+  // void  refitTrack(void* Trk, double NSig);
 
-  void  Test_000(const KalRep* Krep, mu2e::TrkStrawHit* Hit);
+  // void  Test_000(const KalRep* Krep, mu2e::TrkStrawHit* Hit);
 
   ClassDef(TAnaDump,0)
 };

--- a/print/print_kalrep_colls.cc
+++ b/print/print_kalrep_colls.cc
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 //
 ///////////////////////////////////////////////////////////////////////////////
-#include "Offline/RecoDataProducts/inc/KalRepPtrCollection.hh"
+// #include "Offline/RecoDataProducts/inc/KalRepPtrCollection.hh"
 
 #include "Stntuple/print/TAnaDump.hh"
 #include "Stntuple/print/Stntuple_print_functions.hh"
@@ -9,23 +9,23 @@
 void print_kalrep_colls() {
   printf("Available KalRepPtrCollections: \n");
 
-  const art::Event* event = TAnaDump::Instance()->Event();
+  // const art::Event* event = TAnaDump::Instance()->Event();
 
-  art::Selector  selector(art::ProductInstanceNameSelector(""));
+  // art::Selector  selector(art::ProductInstanceNameSelector(""));
 
-  // std::vector<art::Handle<mu2e::KalRepPtrCollection>> vcoll;
-  auto vcoll = event->getMany<mu2e::KalRepPtrCollection>(selector);
+  // // std::vector<art::Handle<mu2e::KalRepPtrCollection>> vcoll;
+  // auto vcoll = event->getMany<mu2e::KalRepPtrCollection>(selector);
 
-  for (auto handle = vcoll.begin(); handle != vcoll.end(); handle++) {
-    if (handle->isValid()) {
-      const art::Provenance* prov = handle->provenance();
+  // for (auto handle = vcoll.begin(); handle != vcoll.end(); handle++) {
+  //   if (handle->isValid()) {
+  //     const art::Provenance* prov = handle->provenance();
       
-      printf("moduleLabel: %-20s, productInstanceName: %-20s, processName:= %-30s\n" ,
-	     prov->moduleLabel().data(),
-	     prov->productInstanceName().data(),
-	     prov->processName().data()
-	     );
-    }
-  }
-  return;
+  //     printf("moduleLabel: %-20s, productInstanceName: %-20s, processName:= %-30s\n" ,
+  //            prov->moduleLabel().data(),
+  //            prov->productInstanceName().data(),
+  //            prov->processName().data()
+  //            );
+  //   }
+  // }
+  // return;
 }

--- a/scripts/stnana.C
+++ b/scripts/stnana.C
@@ -177,6 +177,7 @@ void stnana (TString     Book   ,
         /* DEBUG */  //   printf("[stnana.C]: g.MinRun=%i  g.MaxRun=%i\n",g.MinRun,g.MaxRun);
       }
 
+      // g.catalog->SetPrintLevel(10);
       g.catalog->InitDataset(g.dataset,Book,Dataset,Fileset,File,g.MinRun,g.MaxRun);
 
       if (g.dataset->GetNFiles() <= 0) {


### PR DESCRIPTION
This development work targeted a few things:
- Additional error catching/validation (solved a recent seg fault issue due to high trigger bit values)
- Update sam dataset access with recent tool changes
- Update the Calo cluster payload to include additional reco values used by analyses (e.g. RMC, calo triggers), as well as a few MC fields for use in simulations
- Update interface to trigger navigator object and add new trigger lines to the trigger table
- Comment out or remove BTrk legacy products/includes that no longer exist in Offline (merged with main edits doing this)
- Comment out DoubletAmbiguityResolver, as these are no longer in Offline

The calo cluster changes don't affect reading of old ntuple datasets, but do increase the output dataset sizes due to the large number of calo clusters per mixed event. I also added a new float array for future expansion, as the previous one ran out of room. I also tested running `fcl/reco_trig.fcl` works fine on CE- digi data.